### PR TITLE
#42 feature/order-status - 주문 상태 조회 기능 및 API 구현

### DIFF
--- a/src/main/java/com/t3t/bookstoreapi/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/t3t/bookstoreapi/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.t3t.bookstoreapi.common.exception;
+
+import com.t3t.bookstoreapi.model.response.BaseResponse;
+import com.t3t.bookstoreapi.order.exception.OrderStatusNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * 주문 상태가 존재하지 않는 경우에 대한 예외 처리 핸들러
+     *
+     * @param orderStatusNotFoundException 주문 상태가 존재하지 않는 경우 발생하는 예외
+     * @return 404 NOT_FOUND - 예외 메시지 반환
+     * @author woody35545(구건모)
+     * @see com.t3t.bookstoreapi.order.exception.OrderStatusNotFoundException
+     * @see com.t3t.bookstoreapi.order.exception.OrderStatusNotFoundForIdException
+     * @see com.t3t.bookstoreapi.order.exception.OrderStatusNotFoundForNameException
+     */
+
+    @ExceptionHandler(OrderStatusNotFoundException.class)
+    public ResponseEntity<BaseResponse<Void>> handleOrderStatusNotFoundException(OrderStatusNotFoundException orderStatusNotFoundException) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new BaseResponse<Void>().message(orderStatusNotFoundException.getMessage()));
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/model/response/BaseResponse.java
+++ b/src/main/java/com/t3t/bookstoreapi/model/response/BaseResponse.java
@@ -3,12 +3,14 @@ package com.t3t.bookstoreapi.model.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
+@NoArgsConstructor
 public class BaseResponse<T> {
-    private final String message;
-    private final T data;
+    private String message;
+    private T data;
 
     @Builder
     public BaseResponse(String message, T data) {
@@ -22,4 +24,27 @@ public class BaseResponse<T> {
                 .data(data)
                 .build();
     }
+
+    /**
+     * 응답 객체에 데이터를 설정한다.
+     * @param data 응답할 데이터
+     * @return BaseResponse
+     * @author woody35545(구건모)
+     */
+    public BaseResponse<T> data(T data) {
+        this.data = data;
+        return this;
+    }
+
+    /**
+     * 응답 객체에 메시지를 설정한다.
+     * @param message 응답할 메시지
+     * @return BaseResponse
+     * @author woody35545(구건모)
+     */
+    public BaseResponse<T> message(String message) {
+        this.message = message;
+        return this;
+    }
+
 }

--- a/src/main/java/com/t3t/bookstoreapi/order/constant/OrderStatusType.java
+++ b/src/main/java/com/t3t/bookstoreapi/order/constant/OrderStatusType.java
@@ -1,0 +1,14 @@
+package com.t3t.bookstoreapi.order.constant;
+
+/**
+ * 주문 상태(OrderStatus) 를 나타내는 Enum 클래스<br>
+ * @apiNote 기본적인 주문 상태로 `대기`, `배송중`, `완료`, `반품`, `주문취소`를 가진다.
+ * @author woody35545(구건모)
+ */
+public enum OrderStatusType {
+    PENDING, // 대기
+    DELIVERING, // 배송중
+    DELIVERED, // 완료
+    REFUNDED, // 반품
+    CANCELED; // 주문취소
+}

--- a/src/main/java/com/t3t/bookstoreapi/order/controller/OrderStatusController.java
+++ b/src/main/java/com/t3t/bookstoreapi/order/controller/OrderStatusController.java
@@ -1,0 +1,36 @@
+package com.t3t.bookstoreapi.order.controller;
+
+import com.t3t.bookstoreapi.model.response.BaseResponse;
+import com.t3t.bookstoreapi.order.model.dto.OrderStatusDto;
+import com.t3t.bookstoreapi.order.service.OrderStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderStatusController {
+    private final OrderStatusService orderStatusService;
+
+    /**
+     * 모든 주문 상태를 조회하는 API
+     *
+     * @return 조회된 주문 상태들에 대한 DTO 리스트
+     * @author woody35545(구건모)
+     */
+    @GetMapping("/orders/status")
+    public ResponseEntity<BaseResponse<List<OrderStatusDto>>> getAllOrderStatusList() {
+
+        List<OrderStatusDto> orderStatusDtoList = orderStatusService.getAllOrderStatusList();
+
+        BaseResponse<List<OrderStatusDto>> responseBody = new BaseResponse<>();
+
+        return orderStatusDtoList.isEmpty() ?
+                ResponseEntity.ok(responseBody.message("등록된 주문 상태가 없습니다.")) :
+                ResponseEntity.status(HttpStatus.OK).body(responseBody.data(orderStatusDtoList));
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/order/controller/OrderStatusController.java
+++ b/src/main/java/com/t3t/bookstoreapi/order/controller/OrderStatusController.java
@@ -3,6 +3,7 @@ package com.t3t.bookstoreapi.order.controller;
 import com.t3t.bookstoreapi.model.response.BaseResponse;
 import com.t3t.bookstoreapi.order.model.dto.OrderStatusDto;
 import com.t3t.bookstoreapi.order.service.OrderStatusService;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,8 +20,9 @@ public class OrderStatusController {
 
     /**
      * 모든 주문 상태를 조회하는 API
+     *
      * @return 200 OK - 조회된 주문 상태들에 대한 DTO 리스트 반환<br>
-     *         204 NO_CONTENT - 등록된 주문 상태가 없는 경우 메시지 반환<br>
+     * 204 NO_CONTENT - 등록된 주문 상태가 없는 경우 메시지 반환
      * @author woody35545(구건모)
      */
     @GetMapping("/orders/status")
@@ -36,17 +38,28 @@ public class OrderStatusController {
     }
 
     /**
-     * 주문 상태 식별자로 주문 상태를 조회하는 API<br>
+     * 주문 상태 식별자로 주문 상태를 조회하는 API
      * @param orderStatusId 조회하고자 하는 주문 상태 식별자
-     * @return              200 OK - 조회된 주문 상태에 대한 DTO 반환
+     * @return 200 OK - 조회된 주문 상태에 대한 DTO 반환
+     * @author woody35545(구건모)
      */
     @GetMapping("/orders/status/{orderStatusId}")
     public ResponseEntity<BaseResponse<OrderStatusDto>> getOrderStatusById(@PathVariable long orderStatusId) {
 
-        OrderStatusDto orderStatusDto = orderStatusService.getOrderStatusById(orderStatusId);
+        return ResponseEntity.ok(new BaseResponse<OrderStatusDto>()
+                .data(orderStatusService.getOrderStatusById(orderStatusId)));
+    }
 
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(new BaseResponse<OrderStatusDto>()
-                        .data(orderStatusDto));
+    /**
+     * 주문 상태 이름으로 주문 상태를 조회하는 API
+     * @param statusName 조회하고자 하는 주문 상태 이름
+     * @return 200 OK - 조회된 주문 상태에 대한 DTO 반환
+     * @author woody35545(구건모)
+     */
+    @GetMapping("/orders/status/{statusName}")
+    public ResponseEntity<BaseResponse<OrderStatusDto>> getOrderStatusByName(@PathVariable String statusName) {
+
+        return ResponseEntity.ok(new BaseResponse<OrderStatusDto>()
+                .data(orderStatusService.getOrderStatusByName(statusName)));
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/order/controller/OrderStatusController.java
+++ b/src/main/java/com/t3t/bookstoreapi/order/controller/OrderStatusController.java
@@ -1,12 +1,9 @@
 package com.t3t.bookstoreapi.order.controller;
 
 import com.t3t.bookstoreapi.model.response.BaseResponse;
-import com.t3t.bookstoreapi.order.exception.OrderStatusNotFoundException;
 import com.t3t.bookstoreapi.order.model.dto.OrderStatusDto;
 import com.t3t.bookstoreapi.order.service.OrderStatusService;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,7 +17,6 @@ public class OrderStatusController {
 
     /**
      * 모든 주문 상태를 조회하는 API
-     *
      * @return 200 OK - 조회된 주문 상태들에 대한 DTO 리스트 반환<br>
      * 204 NO_CONTENT - 등록된 주문 상태가 없는 경우 메시지 반환
      * @author woody35545(구건모)

--- a/src/main/java/com/t3t/bookstoreapi/order/controller/OrderStatusController.java
+++ b/src/main/java/com/t3t/bookstoreapi/order/controller/OrderStatusController.java
@@ -1,15 +1,15 @@
 package com.t3t.bookstoreapi.order.controller;
 
 import com.t3t.bookstoreapi.model.response.BaseResponse;
+import com.t3t.bookstoreapi.order.exception.OrderStatusNotFoundException;
 import com.t3t.bookstoreapi.order.model.dto.OrderStatusDto;
 import com.t3t.bookstoreapi.order.service.OrderStatusService;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -44,20 +44,21 @@ public class OrderStatusController {
      * @author woody35545(구건모)
      */
     @GetMapping("/orders/status/{orderStatusId}")
-    public ResponseEntity<BaseResponse<OrderStatusDto>> getOrderStatusById(@PathVariable long orderStatusId) {
+    public ResponseEntity<BaseResponse<OrderStatusDto>> getOrderStatusById(@PathVariable("orderStatusId") long orderStatusId) {
 
         return ResponseEntity.ok(new BaseResponse<OrderStatusDto>()
                 .data(orderStatusService.getOrderStatusById(orderStatusId)));
     }
 
     /**
+     * <b>request: /orders/status?name={statusName}</b><br>
      * 주문 상태 이름으로 주문 상태를 조회하는 API
      * @param statusName 조회하고자 하는 주문 상태 이름
      * @return 200 OK - 조회된 주문 상태에 대한 DTO 반환
      * @author woody35545(구건모)
      */
-    @GetMapping("/orders/status/{statusName}")
-    public ResponseEntity<BaseResponse<OrderStatusDto>> getOrderStatusByName(@PathVariable String statusName) {
+    @GetMapping(value = "/orders/status", params = "name")
+    public ResponseEntity<BaseResponse<OrderStatusDto>> getOrderStatusByName(@RequestParam("name") String statusName) {
 
         return ResponseEntity.ok(new BaseResponse<OrderStatusDto>()
                 .data(orderStatusService.getOrderStatusByName(statusName)));

--- a/src/main/java/com/t3t/bookstoreapi/order/controller/OrderStatusController.java
+++ b/src/main/java/com/t3t/bookstoreapi/order/controller/OrderStatusController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -18,8 +19,8 @@ public class OrderStatusController {
 
     /**
      * 모든 주문 상태를 조회하는 API
-     *
-     * @return 조회된 주문 상태들에 대한 DTO 리스트
+     * @return 200 OK - 조회된 주문 상태들에 대한 DTO 리스트 반환<br>
+     *         204 NO_CONTENT - 등록된 주문 상태가 없는 경우 메시지 반환<br>
      * @author woody35545(구건모)
      */
     @GetMapping("/orders/status")
@@ -30,7 +31,22 @@ public class OrderStatusController {
         BaseResponse<List<OrderStatusDto>> responseBody = new BaseResponse<>();
 
         return orderStatusDtoList.isEmpty() ?
-                ResponseEntity.ok(responseBody.message("등록된 주문 상태가 없습니다.")) :
-                ResponseEntity.status(HttpStatus.OK).body(responseBody.data(orderStatusDtoList));
+                ResponseEntity.status(HttpStatus.NO_CONTENT).body(responseBody.message("등록된 주문 상태가 없습니다.")) :
+                ResponseEntity.ok(responseBody.data(orderStatusDtoList));
+    }
+
+    /**
+     * 주문 상태 식별자로 주문 상태를 조회하는 API<br>
+     * @param orderStatusId 조회하고자 하는 주문 상태 식별자
+     * @return              200 OK - 조회된 주문 상태에 대한 DTO 반환
+     */
+    @GetMapping("/orders/status/{orderStatusId}")
+    public ResponseEntity<BaseResponse<OrderStatusDto>> getOrderStatusById(@PathVariable long orderStatusId) {
+
+        OrderStatusDto orderStatusDto = orderStatusService.getOrderStatusById(orderStatusId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BaseResponse<OrderStatusDto>()
+                        .data(orderStatusDto));
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/order/exception/OrderStatusNotFoundException.java
+++ b/src/main/java/com/t3t/bookstoreapi/order/exception/OrderStatusNotFoundException.java
@@ -1,0 +1,18 @@
+package com.t3t.bookstoreapi.order.exception;
+
+/**
+ * 존재하지 않는 주문 상태(OrderStatus)에 대해 조회를 시도하는 경우 발생하는 예외
+ * @author woody35545(구건모)
+ */
+public class OrderStatusNotFoundException extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 주문 상태(OrderStatus) 입니다.";
+
+    public OrderStatusNotFoundException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    protected OrderStatusNotFoundException(String forTarget) {
+        super(String.format("%s (%s)", DEFAULT_MESSAGE, forTarget));
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/order/exception/OrderStatusNotFoundForIdException.java
+++ b/src/main/java/com/t3t/bookstoreapi/order/exception/OrderStatusNotFoundForIdException.java
@@ -1,0 +1,12 @@
+package com.t3t.bookstoreapi.order.exception;
+
+/**
+ * 주문 상태 식별자로 주문 상태 조회시 해당하는 주문 상태가 존재하지 않는 경우 발생하는 예외
+ * @see OrderStatusNotFoundException
+ * @author woody35545(구건모)
+ */
+public class OrderStatusNotFoundForIdException extends OrderStatusNotFoundException {
+    public OrderStatusNotFoundForIdException(Long id) {
+        super(String.format("id: %d", id));
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/order/exception/OrderStatusNotFoundForNameException.java
+++ b/src/main/java/com/t3t/bookstoreapi/order/exception/OrderStatusNotFoundForNameException.java
@@ -1,0 +1,12 @@
+package com.t3t.bookstoreapi.order.exception;
+
+/**
+ * 주문 상태 이름으로 주문 상태 조회시 해당하는 주문 상태가 존재하지 않는 경우 발생하는 예외
+ * @see OrderStatusNotFoundException
+ * @author woody35545(구건모)
+ */
+public class OrderStatusNotFoundForNameException extends OrderStatusNotFoundException {
+    public OrderStatusNotFoundForNameException(String name) {
+        super(String.format("name: %s", name));
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/order/model/dto/OrderStatusDto.java
+++ b/src/main/java/com/t3t/bookstoreapi/order/model/dto/OrderStatusDto.java
@@ -1,0 +1,20 @@
+package com.t3t.bookstoreapi.order.model.dto;
+
+import com.t3t.bookstoreapi.order.model.entity.OrderStatus;
+import lombok.*;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderStatusDto {
+    private Long id;
+    private String name;
+
+    public static OrderStatusDto of(OrderStatus orderStatus) {
+        return OrderStatusDto.builder()
+                .id(orderStatus.getId())
+                .name(orderStatus.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/order/repository/OrderStatusRepository.java
+++ b/src/main/java/com/t3t/bookstoreapi/order/repository/OrderStatusRepository.java
@@ -3,5 +3,8 @@ package com.t3t.bookstoreapi.order.repository;
 import com.t3t.bookstoreapi.order.model.entity.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OrderStatusRepository extends JpaRepository<OrderStatus, Long> {
+    Optional<OrderStatus> findByName(String name);
 }

--- a/src/main/java/com/t3t/bookstoreapi/order/service/OrderStatusService.java
+++ b/src/main/java/com/t3t/bookstoreapi/order/service/OrderStatusService.java
@@ -1,0 +1,58 @@
+package com.t3t.bookstoreapi.order.service;
+
+import com.t3t.bookstoreapi.order.exception.OrderStatusNotFoundForIdException;
+import com.t3t.bookstoreapi.order.exception.OrderStatusNotFoundForNameException;
+import com.t3t.bookstoreapi.order.model.dto.OrderStatusDto;
+import com.t3t.bookstoreapi.order.repository.OrderStatusRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class OrderStatusService {
+    private final OrderStatusRepository orderStatusRepository;
+
+
+    /**
+     * 모든 주문 상태를 조회한다.
+     * @return 조회된 주문 상태들에 대한 DTO 리스트
+     * @author woody35545(구건모)
+     */
+    @Transactional(readOnly = true)
+    public List<OrderStatusDto> getAllOrderStatusList() {
+        return orderStatusRepository.findAll().stream()
+                .map(OrderStatusDto::of)
+                .collect(Collectors.toList());
+    }
+
+
+    /**
+     * 주문 상태 식별자로 주문 상태를 조회한다.
+     * @param orderStatusId 조회하고자 하는 주문 상태 식별자
+     * @return 조회된 주문 상태에 대한 DTO
+     */
+    @Transactional(readOnly = true)
+    public OrderStatusDto getOrderStatusById(Long orderStatusId) {
+        return OrderStatusDto.of(orderStatusRepository.findById(orderStatusId)
+                .orElseThrow(() -> new OrderStatusNotFoundForIdException(orderStatusId)));
+    }
+
+
+    /**
+     * 주문 상태 이름으로 주문 상태를 조회한다.
+     * @param statusName 조회하고자 하는 주문 상태 이름
+     * @return 조회된 주문 상태에 대한 DTO
+     */
+    @Transactional(readOnly = true)
+    public OrderStatusDto getOrderStatusByName(String statusName) {
+        return OrderStatusDto.of(orderStatusRepository.findByName(statusName)
+                .orElseThrow(() -> new OrderStatusNotFoundForNameException(statusName)));
+    }
+}

--- a/src/test/java/com/t3t/bookstoreapi/order/servcie/OrderStatusServiceUnitTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/order/servcie/OrderStatusServiceUnitTest.java
@@ -1,0 +1,50 @@
+package com.t3t.bookstoreapi.order.servcie;
+
+import com.t3t.bookstoreapi.order.model.dto.OrderStatusDto;
+import com.t3t.bookstoreapi.order.model.entity.OrderStatus;
+import com.t3t.bookstoreapi.order.repository.OrderStatusRepository;
+import com.t3t.bookstoreapi.order.service.OrderStatusService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+
+public class OrderStatusServiceUnitTest {
+    @Mock
+    private OrderStatusRepository orderStatusRepository;
+
+    @InjectMocks
+    private OrderStatusService orderStatusService;
+
+    @Test
+    @DisplayName("주문 상태 전체 조회 테스트")
+    void getAllOrderStatusTest(){
+        // given
+        List<OrderStatus> testOrderStatusList = List.of(
+            OrderStatus.builder().id(0L).name("testOrderStatus1").build(),
+            OrderStatus.builder().id(1L).name("testOrderStatus2").build(),
+            OrderStatus.builder().id(2L).name("testOrderStatus3").build()
+        );
+
+        Mockito.doReturn(testOrderStatusList).when(orderStatusRepository).findAll();
+
+        // when
+        List<OrderStatusDto> resultOrderStatusDtoList = orderStatusService.getAllOrderStatusList();
+
+        // then
+        Assertions.assertEquals(testOrderStatusList.size(), resultOrderStatusDtoList.size());
+
+        for (int i = 0; i < testOrderStatusList.size(); i++) {
+            Assertions.assertEquals(testOrderStatusList.get(i).getId(), resultOrderStatusDtoList.get(i).getId());
+            Assertions.assertEquals(testOrderStatusList.get(i).getName(), resultOrderStatusDtoList.get(i).getName());
+        }
+    }
+}

--- a/src/test/java/com/t3t/bookstoreapi/order/servcie/OrderStatusServiceUnitTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/order/servcie/OrderStatusServiceUnitTest.java
@@ -117,4 +117,23 @@ class OrderStatusServiceUnitTest {
         Assertions.assertEquals(testOrderStatus.getId(), resultOrderStatusDto.getId());
         Assertions.assertEquals(testOrderStatus.getName(), resultOrderStatusDto.getName());
     }
+
+    /**
+     * 주문 상태명으로 주문 상태 조회 테스트<br>
+     * @apiNote 요청한 상태명에 대해 주문 상태가 존재하지 않는 경우 `OrderStatusNotFoundForNameException`가 발생해야 한다.
+     * @see OrderStatusService#getOrderStatusByName(String)
+     * @see OrderStatusNotFoundForNameException
+     * @author woody35545(구건모)
+     */
+    @Test
+    @DisplayName("주문 상태 조회 - 상태명으로 조회(존재하지 않는 주문 상태 요청)")
+    void getOrderStatusByNameExceptionTest() {
+        // given
+        String testOrderStatusName = "testOrderStatus";
+
+        Mockito.when(orderStatusRepository.findByName(testOrderStatusName)).thenReturn(Optional.empty());
+
+        // when & then
+        Assertions.assertThrows(OrderStatusNotFoundForNameException.class, () -> orderStatusService.getOrderStatusByName(testOrderStatusName));
+    }
 }

--- a/src/test/java/com/t3t/bookstoreapi/order/servcie/OrderStatusServiceUnitTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/order/servcie/OrderStatusServiceUnitTest.java
@@ -14,9 +14,9 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
-
 public class OrderStatusServiceUnitTest {
     @Mock
     private OrderStatusRepository orderStatusRepository;
@@ -24,14 +24,19 @@ public class OrderStatusServiceUnitTest {
     @InjectMocks
     private OrderStatusService orderStatusService;
 
+    /**
+     * 주문 상태 전체 조회 테스트
+     * @see OrderStatusService#getAllOrderStatusList()
+     * @author woody35545(구건모)
+     */
     @Test
     @DisplayName("주문 상태 전체 조회 테스트")
-    void getAllOrderStatusTest(){
+    void getAllOrderStatusListTest(){
         // given
         List<OrderStatus> testOrderStatusList = List.of(
-            OrderStatus.builder().id(0L).name("testOrderStatus1").build(),
-            OrderStatus.builder().id(1L).name("testOrderStatus2").build(),
-            OrderStatus.builder().id(2L).name("testOrderStatus3").build()
+            OrderStatus.builder().id(0L).name("testOrderStatus0").build(),
+            OrderStatus.builder().id(1L).name("testOrderStatus1").build(),
+            OrderStatus.builder().id(2L).name("testOrderStatus2").build()
         );
 
         Mockito.doReturn(testOrderStatusList).when(orderStatusRepository).findAll();
@@ -46,5 +51,26 @@ public class OrderStatusServiceUnitTest {
             Assertions.assertEquals(testOrderStatusList.get(i).getId(), resultOrderStatusDtoList.get(i).getId());
             Assertions.assertEquals(testOrderStatusList.get(i).getName(), resultOrderStatusDtoList.get(i).getName());
         }
+    }
+
+    /**
+     * 주문 상태 식별자로 주문 상태 조회 테스트
+     * @see OrderStatusService#getOrderStatusById(Long)
+     * @author woody35545(구건모)
+     */
+    @Test
+    @DisplayName("주문 상태 식별자로 주문 상태 조회 테스트")
+    void getOrderStatusByIdTest(){
+        // given
+        OrderStatus testOrderStatus = OrderStatus.builder().id(0L).name("testOrderStatus").build();
+
+        Mockito.when(orderStatusRepository.findById(0L)).thenReturn(Optional.of(testOrderStatus));
+
+        // when
+        OrderStatusDto resultOrderStatusDto = orderStatusService.getOrderStatusById(0L);
+
+        // then
+        Assertions.assertEquals(testOrderStatus.getId(), resultOrderStatusDto.getId());
+        Assertions.assertEquals(testOrderStatus.getName(), resultOrderStatusDto.getName());
     }
 }

--- a/src/test/java/com/t3t/bookstoreapi/order/servcie/OrderStatusServiceUnitTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/order/servcie/OrderStatusServiceUnitTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
-public class OrderStatusServiceUnitTest {
+class OrderStatusServiceUnitTest {
     @Mock
     private OrderStatusRepository orderStatusRepository;
 
@@ -26,17 +26,18 @@ public class OrderStatusServiceUnitTest {
 
     /**
      * 주문 상태 전체 조회 테스트
-     * @see OrderStatusService#getAllOrderStatusList()
+     *
      * @author woody35545(구건모)
+     * @see OrderStatusService#getAllOrderStatusList()
      */
     @Test
-    @DisplayName("주문 상태 전체 조회 테스트")
-    void getAllOrderStatusListTest(){
+    @DisplayName("주문 상태 조회 - 전체 조회")
+    void getAllOrderStatusListTest() {
         // given
         List<OrderStatus> testOrderStatusList = List.of(
-            OrderStatus.builder().id(0L).name("testOrderStatus0").build(),
-            OrderStatus.builder().id(1L).name("testOrderStatus1").build(),
-            OrderStatus.builder().id(2L).name("testOrderStatus2").build()
+                OrderStatus.builder().id(0L).name("testOrderStatus0").build(),
+                OrderStatus.builder().id(1L).name("testOrderStatus1").build(),
+                OrderStatus.builder().id(2L).name("testOrderStatus2").build()
         );
 
         Mockito.doReturn(testOrderStatusList).when(orderStatusRepository).findAll();
@@ -55,19 +56,41 @@ public class OrderStatusServiceUnitTest {
 
     /**
      * 주문 상태 식별자로 주문 상태 조회 테스트
-     * @see OrderStatusService#getOrderStatusById(Long)
+     *
      * @author woody35545(구건모)
+     * @see OrderStatusService#getOrderStatusById(Long)
      */
     @Test
-    @DisplayName("주문 상태 식별자로 주문 상태 조회 테스트")
-    void getOrderStatusByIdTest(){
+    @DisplayName("주문 상태 조회 - 식별자로 조회")
+    void getOrderStatusByIdTest() {
         // given
         OrderStatus testOrderStatus = OrderStatus.builder().id(0L).name("testOrderStatus").build();
 
-        Mockito.when(orderStatusRepository.findById(0L)).thenReturn(Optional.of(testOrderStatus));
+        Mockito.when(orderStatusRepository.findById(testOrderStatus.getId())).thenReturn(Optional.of(testOrderStatus));
 
         // when
-        OrderStatusDto resultOrderStatusDto = orderStatusService.getOrderStatusById(0L);
+        OrderStatusDto resultOrderStatusDto = orderStatusService.getOrderStatusById(testOrderStatus.getId());
+
+        // then
+        Assertions.assertEquals(testOrderStatus.getId(), resultOrderStatusDto.getId());
+        Assertions.assertEquals(testOrderStatus.getName(), resultOrderStatusDto.getName());
+    }
+
+    /**
+     * 주문 상태명으로 주문 상태 조회 테스트
+     * @see OrderStatusService#getOrderStatusByName(String)
+     * @author woody35545(구건모)
+     */
+    @Test
+    @DisplayName("주문 상태 조회 - 상태명으로 조회")
+    void getOrderStatusByNameTest() {
+        // given
+        OrderStatus testOrderStatus = OrderStatus.builder().id(0L).name("testOrderStatus").build();
+
+        Mockito.when(orderStatusRepository.findByName(testOrderStatus.getName())).thenReturn(Optional.of(testOrderStatus));
+
+        // when
+        OrderStatusDto resultOrderStatusDto = orderStatusService.getOrderStatusByName(testOrderStatus.getName());
 
         // then
         Assertions.assertEquals(testOrderStatus.getId(), resultOrderStatusDto.getId());

--- a/src/test/java/com/t3t/bookstoreapi/order/servcie/OrderStatusServiceUnitTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/order/servcie/OrderStatusServiceUnitTest.java
@@ -1,5 +1,7 @@
 package com.t3t.bookstoreapi.order.servcie;
 
+import com.t3t.bookstoreapi.order.exception.OrderStatusNotFoundForIdException;
+import com.t3t.bookstoreapi.order.exception.OrderStatusNotFoundForNameException;
 import com.t3t.bookstoreapi.order.model.dto.OrderStatusDto;
 import com.t3t.bookstoreapi.order.model.entity.OrderStatus;
 import com.t3t.bookstoreapi.order.repository.OrderStatusRepository;
@@ -74,6 +76,25 @@ class OrderStatusServiceUnitTest {
         // then
         Assertions.assertEquals(testOrderStatus.getId(), resultOrderStatusDto.getId());
         Assertions.assertEquals(testOrderStatus.getName(), resultOrderStatusDto.getName());
+    }
+
+    /**
+     * 주문 상태 식별자로 주문 상태 조회 테스트<br>
+     * @apiNote 요청한 식별자에 대해 주문 상태가 존재하지 않는 경우 `OrderStatusNotFoundForIdException`가 발생해야 한다.
+     * @see OrderStatusService#getOrderStatusById(Long)
+     * @see OrderStatusNotFoundForIdException
+     * @author woody35545(구건모)
+     */
+    @Test
+    @DisplayName("주문 상태 조회 - 식별자로 조회(존재하지 않는 주문 상태 요청)")
+    void getOrderStatusByIdExceptionTest() {
+        // given
+        Long testOrderStatusId = 0L;
+
+        Mockito.when(orderStatusRepository.findById(testOrderStatusId)).thenReturn(Optional.empty());
+
+        // when & then
+        Assertions.assertThrows(OrderStatusNotFoundForIdException.class, () -> orderStatusService.getOrderStatusById(testOrderStatusId));
     }
 
     /**


### PR DESCRIPTION
**구현 내용**
- `OrderStatusController`
  - [x] 등록된 모든 주문 상태 조회 API
  - [x] 주문 상태 식별자로 조회 API
  - [x] 주문 상태명으로 조회 API
- `OrderStatusService`
  - [x] 등록된 모든 주문 상태 조회
  - [x] 주문 상태 식별자로 조회
  - [x] 주문 상태명으로 조회
- `GlobalExceptionHandler`
  - [x] 존재하지 않는 주문에 대한 조회 요청 예외 처리

**테스트 항목**
  - `OrderStatusServiceUnitTest`
    - 등록된 모든 주문 상태 조회 단위 테스트
      - [x] 정상 상황 테스트
    - 주문 상태 식별자로 조회 단위 테스트
       - [x] 정상 상황 테스트
      - [x] 예외 상황 - 요청한 식별자에 대해 주문 상태가 존재하지 않는 경우 테스트
    - 주문 상태명으로 조회 단위 테스트
      - [x] 정상 상황 테스트
      - [x] 예외 상황 - 요청한 상태명에 대해 주문 상태가 존재하지 않는 경우 테스트