### PR TITLE
feature/shoppingcart - 장바구니 항목 생성, 조회, 변경, 삭제 API 구현(#51, #52, #53, #54)

### DIFF
--- a/src/main/java/com/t3t/bookstoreapi/book/exception/BookNotFoundException.java
+++ b/src/main/java/com/t3t/bookstoreapi/book/exception/BookNotFoundException.java
@@ -1,0 +1,16 @@
+package com.t3t.bookstoreapi.book.exception;
+
+/**
+ * 존재하지 않는 책에 대해 조회를 시도하는 경우 발생하는 예외
+ * @author woody35545(구건모)
+ */
+public class BookNotFoundException extends RuntimeException{
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 책 입니다.";
+    public BookNotFoundException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    protected BookNotFoundException(String forTarget) {
+        super(String.format("%s (%s)", DEFAULT_MESSAGE, forTarget));
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/book/exception/BookNotFoundForIdException.java
+++ b/src/main/java/com/t3t/bookstoreapi/book/exception/BookNotFoundForIdException.java
@@ -1,0 +1,12 @@
+package com.t3t.bookstoreapi.book.exception;
+
+/**
+ * 존재하지 않는 책 식별자에 대해 조회를 시도하는 경우 발생하는 예외
+ * @see BookNotFoundException
+ * @author woody35545(구건모)
+ */
+public class BookNotFoundForIdException extends BookNotFoundException{
+    public BookNotFoundForIdException(Long id) {
+        super(String.format("id: %d", id));
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/t3t/bookstoreapi/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.t3t.bookstoreapi.common.exception;
 
+import com.t3t.bookstoreapi.book.exception.BookNotFoundException;
 import com.t3t.bookstoreapi.model.response.BaseResponse;
 import com.t3t.bookstoreapi.order.exception.OrderStatusNotFoundException;
 import com.t3t.bookstoreapi.shoppingcart.exception.ShoppingCartNotFoundException;
@@ -40,5 +41,29 @@ public class GlobalExceptionHandler {
     public ResponseEntity<BaseResponse<Void>> handleShoppingCartNotFoundException(ShoppingCartNotFoundException shoppingCartNotFoundException) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new BaseResponse<Void>().message(shoppingCartNotFoundException.getMessage()));
+    }
+
+    /**
+     * 책이 존재하지 않는 경우에 대한 예외 처리 핸들러
+     * @param bookNotFoundException 책이 존재하지 않는 경우 발생하는 예외
+     * @return 404 NOT_FOUND - 예외 메시지 반환
+     * @author woody35545(구건모)
+     */
+    @ExceptionHandler(BookNotFoundException.class)
+    public ResponseEntity<BaseResponse<Void>> handleBookNotFoundException(BookNotFoundException bookNotFoundException) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new BaseResponse<Void>().message(bookNotFoundException.getMessage()));
+    }
+
+    /**
+     * 잘못된 인자가 전달된 경우에 대한 예외 처리 핸들러
+     * @param illegalArgumentException 잘못된 인자가 전달된 경우 발생하는 예외
+     * @return 400 BAD_REQUEST - 예외 메시지 반환
+     * @author woody35545(구건모)
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<BaseResponse<Void>> handleIllegalArgumentException(IllegalArgumentException illegalArgumentException) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new BaseResponse<Void>().message(illegalArgumentException.getMessage()));
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/t3t/bookstoreapi/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.t3t.bookstoreapi.common.exception;
 
 import com.t3t.bookstoreapi.model.response.BaseResponse;
 import com.t3t.bookstoreapi.order.exception.OrderStatusNotFoundException;
+import com.t3t.bookstoreapi.shoppingcart.exception.ShoppingCartNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -25,5 +26,19 @@ public class GlobalExceptionHandler {
     public ResponseEntity<BaseResponse<Void>> handleOrderStatusNotFoundException(OrderStatusNotFoundException orderStatusNotFoundException) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new BaseResponse<Void>().message(orderStatusNotFoundException.getMessage()));
+    }
+
+    /**
+     * 장바구니가 존재하지 않는 경우에 대한 예외 처리 핸들러
+     * @param shoppingCartNotFoundException 장바구니가 존재하지 않는 경우 발생하는 예외
+     * @see com.t3t.bookstoreapi.shoppingcart.exception.ShoppingCartNotFoundException
+     * @see com.t3t.bookstoreapi.shoppingcart.exception.ShoppingCartNotFoundForIdException
+     * @return 404 NOT_FOUND - 예외 메시지 반환
+     * @author woody35545(구건모)
+     */
+    @ExceptionHandler(ShoppingCartNotFoundException.class)
+    public ResponseEntity<BaseResponse<Void>> handleShoppingCartNotFoundException(ShoppingCartNotFoundException shoppingCartNotFoundException) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new BaseResponse<Void>().message(shoppingCartNotFoundException.getMessage()));
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/controller/ShoppingCartDetailController.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/controller/ShoppingCartDetailController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Min;
 import java.util.List;
 
 @RestController
@@ -50,6 +51,20 @@ public class ShoppingCartDetailController {
                                                                                         @Valid @RequestBody ShoppingCartDetailCreationRequest request) {
         return ResponseEntity.ok(new BaseResponse<ShoppingCartDetailDto>()
                 .data(shoppingCartDetailService.createShoppingCartDetail(shoppingCartId, request)));
+    }
+
+    /**
+     * 장바구니 항목 수량 변경
+     * @param shoppingCartDetailId 변경하려는 장바구니 항목 식별자
+     * @param quantity             변경할 수량
+     * @return 200 OK, 변경된 장바구니 항목에 대한 DTO
+     * @author wooody35545(구건모)
+     */
+    @PutMapping(value = "/shoppingcart-details/{shoppingCartDetailId}", params = "quantity")
+    public ResponseEntity<BaseResponse<ShoppingCartDetailDto>> updateShoppingCartDetailQuantity(@PathVariable("shoppingCartDetailId") long shoppingCartDetailId,
+                                                                                                @RequestParam("quantity") @Min(1) long quantity) {
+        return ResponseEntity.ok(new BaseResponse<ShoppingCartDetailDto>()
+                .data(shoppingCartDetailService.updateShoppingCartDetailQuantity(shoppingCartDetailId, quantity)));
     }
 
     /**

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/controller/ShoppingCartDetailController.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/controller/ShoppingCartDetailController.java
@@ -1,0 +1,38 @@
+package com.t3t.bookstoreapi.shoppingcart.controller;
+
+import com.t3t.bookstoreapi.model.response.BaseResponse;
+import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCartDetail;
+import com.t3t.bookstoreapi.shoppingcart.service.ShoppingCartDetailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ShoppingCartDetailController {
+
+    private final ShoppingCartDetailService shoppingCartDetailService;
+
+    /**
+     * 장바구니 식별자로 전체 항목 리스트 조회
+     * @param shoppingCartId 조회하려는 장바구니 식별자
+     * @return 장바구니 식별자에 해당하는 전체 항목 리스트
+     * @author wooody35545(구건모)
+     */
+    @GetMapping("/shoppingcarts/{shoppingCartId}/details")
+    public ResponseEntity<BaseResponse<List<ShoppingCartDetail>>> getShoppingCartDetailList(@PathVariable("shoppingCartId") long shoppingCartId) {
+        List<ShoppingCartDetail> shoppingCartDetailList =
+                shoppingCartDetailService.getShoppingCartDetailList(shoppingCartId);
+
+        return shoppingCartDetailList.isEmpty() ?
+                ResponseEntity.status(HttpStatus.NO_CONTENT).
+                        body(new BaseResponse<List<ShoppingCartDetail>>().message("장바구니에 담긴 상품이 없습니다.")) :
+                ResponseEntity.ok(new BaseResponse<List<ShoppingCartDetail>>()
+                        .data(shoppingCartDetailList));
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/controller/ShoppingCartDetailController.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/controller/ShoppingCartDetailController.java
@@ -22,7 +22,8 @@ public class ShoppingCartDetailController {
     /**
      * 장바구니 식별자로 전체 항목 리스트 조회
      * @param shoppingCartId 조회하려는 장바구니 식별자
-     * @return 장바구니 식별자에 해당하는 전체 항목 리스트
+     * @return 200 OK, 장바구니 식별자에 해당하는 전체 항목 리스트<br>
+     *         204 No Content, 장바구니에 담긴 상품이 없는 경우 메시지 반환
      * @author wooody35545(구건모)
      */
     @GetMapping("/shoppingcarts/{shoppingCartId}/details")
@@ -41,7 +42,7 @@ public class ShoppingCartDetailController {
      * 장바구니에 항목 추가
      * @param shoppingCartId 장바구니 식별자
      * @param request        추가할 장바구니 항목 정보
-     * @return 추가된 장바구니 항목에 대한 DTO
+     * @return 200 OK, 추가된 장바구니 항목에 대한 DTO
      * @author wooody35545(구건모)
      */
     @PostMapping("/shoppingcarts/{shoppingCartId}/details")
@@ -49,5 +50,17 @@ public class ShoppingCartDetailController {
                                                                                         @Valid @RequestBody ShoppingCartDetailCreationRequest request) {
         return ResponseEntity.ok(new BaseResponse<ShoppingCartDetailDto>()
                 .data(shoppingCartDetailService.createShoppingCartDetail(shoppingCartId, request)));
+    }
+
+    /**
+     * 장바구니 항목 삭제
+     * @param shoppingCartDetailId 삭제하려는 장바구니 항목 식별자
+     * @return 200 OK
+     * @author wooody35545(구건모)
+     */
+    @DeleteMapping("/shoppingcart-details/{shoppingCartDetailId}")
+    public ResponseEntity<BaseResponse<Void>> deleteShoppingCartDetail(@PathVariable("shoppingCartDetailId") long shoppingCartDetailId) {
+        shoppingCartDetailService.deleteShoppingCartDetail(shoppingCartDetailId);
+        return ResponseEntity.ok(new BaseResponse<Void>());
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/controller/ShoppingCartDetailController.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/controller/ShoppingCartDetailController.java
@@ -1,15 +1,16 @@
 package com.t3t.bookstoreapi.shoppingcart.controller;
 
 import com.t3t.bookstoreapi.model.response.BaseResponse;
+import com.t3t.bookstoreapi.shoppingcart.model.dto.ShoppingCartDetailDto;
 import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCartDetail;
+import com.t3t.bookstoreapi.shoppingcart.model.request.ShoppingCartDetailCreationRequest;
 import com.t3t.bookstoreapi.shoppingcart.service.ShoppingCartDetailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -34,5 +35,19 @@ public class ShoppingCartDetailController {
                         body(new BaseResponse<List<ShoppingCartDetail>>().message("장바구니에 담긴 상품이 없습니다.")) :
                 ResponseEntity.ok(new BaseResponse<List<ShoppingCartDetail>>()
                         .data(shoppingCartDetailList));
+    }
+
+    /**
+     * 장바구니에 항목 추가
+     * @param shoppingCartId 장바구니 식별자
+     * @param request        추가할 장바구니 항목 정보
+     * @return 추가된 장바구니 항목에 대한 DTO
+     * @author wooody35545(구건모)
+     */
+    @PostMapping("/shoppingcarts/{shoppingCartId}/details")
+    public ResponseEntity<BaseResponse<ShoppingCartDetailDto>> createShoppingCartDetail(@PathVariable("shoppingCartId") long shoppingCartId,
+                                                                                        @Valid @RequestBody ShoppingCartDetailCreationRequest request) {
+        return ResponseEntity.ok(new BaseResponse<ShoppingCartDetailDto>()
+                .data(shoppingCartDetailService.createShoppingCartDetail(shoppingCartId, request)));
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/exception/ShoppingCartDetailNotFoundException.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/exception/ShoppingCartDetailNotFoundException.java
@@ -1,0 +1,16 @@
+package com.t3t.bookstoreapi.shoppingcart.exception;
+
+/**
+ * 존재하지 않는 장바구니 상세 항목 식별자에 대해 조회를 시도하는 경우 발생하는 예외
+ * @author woody35545(구건모)
+ */
+public class ShoppingCartDetailNotFoundException extends RuntimeException{
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 장바구니 항목입니다.";
+    public ShoppingCartDetailNotFoundException(Long id) {
+        super(DEFAULT_MESSAGE);
+    }
+
+    protected ShoppingCartDetailNotFoundException(String forTarget) {
+        super(String.format("%s (%s)", DEFAULT_MESSAGE, forTarget));
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/exception/ShoppingCartDetailNotFoundForIdException.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/exception/ShoppingCartDetailNotFoundForIdException.java
@@ -1,0 +1,12 @@
+package com.t3t.bookstoreapi.shoppingcart.exception;
+
+/**
+ * 존재하지 않는 장바구니 상세 항목 식별자에 대해 조회를 시도하는 경우 발생하는 예외
+ * @see ShoppingCartNotFoundException
+ * @author woody35545(구건모)
+ */
+public class ShoppingCartDetailNotFoundForIdException extends ShoppingCartNotFoundException{
+    public ShoppingCartDetailNotFoundForIdException(Long id) {
+        super(String.format("id: %d", id));
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/exception/ShoppingCartNotFoundException.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/exception/ShoppingCartNotFoundException.java
@@ -1,0 +1,16 @@
+package com.t3t.bookstoreapi.shoppingcart.exception;
+
+/**
+ * 존재하지 않는 장바구니에 대해 조회를 시도하는 경우 발생하는 예외
+ * @author woody35545(구건모)
+ */
+public class ShoppingCartNotFoundException extends RuntimeException{
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 장바구니 입니다.";
+    public ShoppingCartNotFoundException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    protected ShoppingCartNotFoundException(String forTarget) {
+        super(String.format("%s (%s)", DEFAULT_MESSAGE, forTarget));
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/exception/ShoppingCartNotFoundForIdException.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/exception/ShoppingCartNotFoundForIdException.java
@@ -1,0 +1,12 @@
+package com.t3t.bookstoreapi.shoppingcart.exception;
+
+/**
+ * 존재하지 않는 장바구니 식별자에 대해 조회를 시도하는 경우 발생하는 예외
+ * @see ShoppingCartNotFoundException
+ * @author woody35545(구건모)
+ */
+public class ShoppingCartNotFoundForIdException extends ShoppingCartNotFoundException {
+    public ShoppingCartNotFoundForIdException(Long id) {
+        super(String.format("id: %d", id));
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/model/dto/ShoppingCartDetailDto.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/model/dto/ShoppingCartDetailDto.java
@@ -25,12 +25,12 @@ public class ShoppingCartDetailDto {
     // 수량
     private Long quantity;
 
-    public static ShoppingCartDetail of(ShoppingCartDetailDto dto) {
-        return ShoppingCartDetail.builder()
-                .id(dto.getId())
-                .book(dto.getBook())
-                .shoppingCart(dto.getShoppingCart())
-                .quantity(dto.getQuantity())
+    public static ShoppingCartDetailDto of(ShoppingCartDetail shoppingCartDetail) {
+        return ShoppingCartDetailDto.builder()
+                .id(shoppingCartDetail.getId())
+                .book(shoppingCartDetail.getBook())
+                .shoppingCart(shoppingCartDetail.getShoppingCart())
+                .quantity(shoppingCartDetail.getQuantity())
                 .build();
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/model/dto/ShoppingCartDetailDto.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/model/dto/ShoppingCartDetailDto.java
@@ -1,0 +1,36 @@
+package com.t3t.bookstoreapi.shoppingcart.model.dto;
+
+import com.t3t.bookstoreapi.book.model.entity.Book;
+import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCart;
+import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCartDetail;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ShoppingCartDetailDto {
+    // 장바구니 상세 항목 식별자
+    private Long id;
+
+    // 책 정보
+    private Book book;
+
+    // 속한 장바구니 정보
+    private ShoppingCart shoppingCart;
+
+    // 수량
+    private Long quantity;
+
+    public static ShoppingCartDetail of(ShoppingCartDetailDto dto) {
+        return ShoppingCartDetail.builder()
+                .id(dto.getId())
+                .book(dto.getBook())
+                .shoppingCart(dto.getShoppingCart())
+                .quantity(dto.getQuantity())
+                .build();
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/model/entity/ShoppingCartDetail.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/model/entity/ShoppingCartDetail.java
@@ -1,10 +1,7 @@
 package com.t3t.bookstoreapi.shoppingcart.model.entity;
 
 import com.t3t.bookstoreapi.book.model.entity.Book;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.Comment;
 
 import javax.persistence.*;
@@ -32,6 +29,7 @@ public class ShoppingCartDetail {
     @Comment("장바구니 상세 항목이 속한 장바구니")
     private ShoppingCart shoppingCart;
 
+    @Setter
     @Column(name = "book_quantity", nullable = false)
     @Comment("책 수량")
     private Long quantity;

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/model/request/ShoppingCartDetailCreationRequest.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/model/request/ShoppingCartDetailCreationRequest.java
@@ -1,0 +1,20 @@
+package com.t3t.bookstoreapi.shoppingcart.model.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class ShoppingCartDetailCreationRequest {
+    @NotNull
+    private Long bookId;
+    @NotNull
+    @Min(1)
+    private Long quantity;
+}

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/repository/ShoppingCartDetailRepository.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/repository/ShoppingCartDetailRepository.java
@@ -1,0 +1,10 @@
+package com.t3t.bookstoreapi.shoppingcart.repository;
+
+import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCartDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ShoppingCartDetailRepository extends JpaRepository<ShoppingCartDetail, Long>{
+    List<ShoppingCartDetail> findAllByShoppingCartId(Long shoppingCartId);
+}

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/repository/ShoppingCartRepository.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/repository/ShoppingCartRepository.java
@@ -1,0 +1,7 @@
+package com.t3t.bookstoreapi.shoppingcart.repository;
+
+import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShoppingCartRepository extends JpaRepository<ShoppingCart, Long>{
+}

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailService.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailService.java
@@ -1,0 +1,36 @@
+package com.t3t.bookstoreapi.shoppingcart.service;
+
+import com.t3t.bookstoreapi.shoppingcart.exception.ShoppingCartNotFoundForIdException;
+import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCartDetail;
+import com.t3t.bookstoreapi.shoppingcart.repository.ShoppingCartDetailRepository;
+import com.t3t.bookstoreapi.shoppingcart.repository.ShoppingCartRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ShoppingCartDetailService {
+
+    private final ShoppingCartDetailRepository shoppingCartDetailRepository;
+    private final ShoppingCartRepository shoppingCartRepository;
+
+    /**
+     * 장바구니 식별자로 전체 항목 리스트 조회
+     * @param shoppingCartId 조회하려는 장바구니 식별자
+     * @return 장바구니 식별자에 해당하는 전체 항목 리스트
+     * @author wooody35545(구건모)
+     */
+    @Transactional(readOnly = true)
+    public List<ShoppingCartDetail> getShoppingCartDetailList(long shoppingCartId) {
+
+        if (!shoppingCartRepository.existsById(shoppingCartId)) {
+            throw new ShoppingCartNotFoundForIdException(shoppingCartId);
+        }
+
+        return shoppingCartDetailRepository.findAllByShoppingCartId(shoppingCartId);
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailService.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailService.java
@@ -1,6 +1,11 @@
 package com.t3t.bookstoreapi.shoppingcart.service;
 
+import com.t3t.bookstoreapi.book.exception.BookNotFoundForIdException;
+import com.t3t.bookstoreapi.book.model.entity.Book;
+import com.t3t.bookstoreapi.book.repository.BookRepository;
 import com.t3t.bookstoreapi.shoppingcart.exception.ShoppingCartNotFoundForIdException;
+import com.t3t.bookstoreapi.shoppingcart.model.dto.ShoppingCartDetailDto;
+import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCart;
 import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCartDetail;
 import com.t3t.bookstoreapi.shoppingcart.repository.ShoppingCartDetailRepository;
 import com.t3t.bookstoreapi.shoppingcart.repository.ShoppingCartRepository;
@@ -17,6 +22,7 @@ public class ShoppingCartDetailService {
 
     private final ShoppingCartDetailRepository shoppingCartDetailRepository;
     private final ShoppingCartRepository shoppingCartRepository;
+    private final BookRepository bookRepository;
 
     /**
      * 장바구니 식별자로 전체 항목 리스트 조회
@@ -32,5 +38,28 @@ public class ShoppingCartDetailService {
         }
 
         return shoppingCartDetailRepository.findAllByShoppingCartId(shoppingCartId);
+    }
+
+    /**
+     * 장바구니에 항목 추가
+     * @param shoppingCartId 장바구니 식별자
+     * @param bookId 추가할 책 식별자
+     * @param quantity 추가할 수량
+     * @return 추가된 장바구니 항목에 대한 DTO
+     * @author wooody35545(구건모)
+     */
+    public ShoppingCartDetailDto createShoppingCartDetail(long shoppingCartId, long bookId, long quantity) {
+
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("수량은 0보다 커야 합니다.");
+        }
+
+        return ShoppingCartDetailDto.of(shoppingCartDetailRepository.save(ShoppingCartDetail.builder()
+                .shoppingCart(shoppingCartRepository.findById(shoppingCartId)
+                        .orElseThrow(() -> new ShoppingCartNotFoundForIdException(shoppingCartId)))
+                .book(bookRepository.findById(bookId)
+                        .orElseThrow(() -> new BookNotFoundForIdException(bookId)))
+                .quantity(quantity)
+                .build()));
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailService.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailService.java
@@ -65,6 +65,26 @@ public class ShoppingCartDetailService {
     }
 
     /**
+     * 특정 장바구니 항목의 수량을 변경한다.
+     * @param shoppingCartDetailId 변경할 장바구니 항목 식별자
+     * @param quantity 변경할 수량
+     * @return 변경된 장바구니 항목에 대한 DTO
+     * @author wooody35545(구건모)
+     */
+    public ShoppingCartDetailDto updateShoppingCartDetailQuantity(long shoppingCartDetailId, long quantity) {
+        ShoppingCartDetail shoppingCartDetail = shoppingCartDetailRepository.findById(shoppingCartDetailId)
+                .orElseThrow(() -> new ShoppingCartDetailNotFoundForIdException(shoppingCartDetailId));
+
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("수량은 0보다 커야 합니다.");
+        }
+
+        shoppingCartDetail.setQuantity(quantity);
+
+        return ShoppingCartDetailDto.of(shoppingCartDetail);
+    }
+
+    /**
      * 장바구니 항목 삭제
      * @param shoppingCartDetailId 삭제할 장바구니 항목 식별자
      * @author wooody35545(구건모)

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailService.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailService.java
@@ -3,6 +3,7 @@ package com.t3t.bookstoreapi.shoppingcart.service;
 import com.t3t.bookstoreapi.book.exception.BookNotFoundForIdException;
 import com.t3t.bookstoreapi.book.model.entity.Book;
 import com.t3t.bookstoreapi.book.repository.BookRepository;
+import com.t3t.bookstoreapi.shoppingcart.exception.ShoppingCartDetailNotFoundForIdException;
 import com.t3t.bookstoreapi.shoppingcart.exception.ShoppingCartNotFoundForIdException;
 import com.t3t.bookstoreapi.shoppingcart.model.dto.ShoppingCartDetailDto;
 import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCart;
@@ -61,5 +62,15 @@ public class ShoppingCartDetailService {
                         .orElseThrow(() -> new BookNotFoundForIdException(bookId)))
                 .quantity(quantity)
                 .build()));
+    }
+
+    /**
+     * 장바구니 항목 삭제
+     * @param shoppingCartDetailId 삭제할 장바구니 항목 식별자
+     * @author wooody35545(구건모)
+     */
+    public void deleteShoppingCartDetail(long shoppingCartDetailId) {
+        shoppingCartDetailRepository.delete(shoppingCartDetailRepository.findById(shoppingCartDetailId)
+                .orElseThrow(() -> new ShoppingCartDetailNotFoundForIdException(shoppingCartDetailId)));
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailService.java
+++ b/src/main/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailService.java
@@ -8,6 +8,7 @@ import com.t3t.bookstoreapi.shoppingcart.exception.ShoppingCartNotFoundForIdExce
 import com.t3t.bookstoreapi.shoppingcart.model.dto.ShoppingCartDetailDto;
 import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCart;
 import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCartDetail;
+import com.t3t.bookstoreapi.shoppingcart.model.request.ShoppingCartDetailCreationRequest;
 import com.t3t.bookstoreapi.shoppingcart.repository.ShoppingCartDetailRepository;
 import com.t3t.bookstoreapi.shoppingcart.repository.ShoppingCartRepository;
 import lombok.RequiredArgsConstructor;
@@ -44,23 +45,22 @@ public class ShoppingCartDetailService {
     /**
      * 장바구니에 항목 추가
      * @param shoppingCartId 장바구니 식별자
-     * @param bookId 추가할 책 식별자
-     * @param quantity 추가할 수량
+     * @param request 추가할 장바구니 항목 정보
      * @return 추가된 장바구니 항목에 대한 DTO
      * @author wooody35545(구건모)
      */
-    public ShoppingCartDetailDto createShoppingCartDetail(long shoppingCartId, long bookId, long quantity) {
+    public ShoppingCartDetailDto createShoppingCartDetail(long shoppingCartId, ShoppingCartDetailCreationRequest request) {
 
-        if (quantity <= 0) {
+        if (request.getQuantity() <= 0) {
             throw new IllegalArgumentException("수량은 0보다 커야 합니다.");
         }
 
         return ShoppingCartDetailDto.of(shoppingCartDetailRepository.save(ShoppingCartDetail.builder()
                 .shoppingCart(shoppingCartRepository.findById(shoppingCartId)
                         .orElseThrow(() -> new ShoppingCartNotFoundForIdException(shoppingCartId)))
-                .book(bookRepository.findById(bookId)
-                        .orElseThrow(() -> new BookNotFoundForIdException(bookId)))
-                .quantity(quantity)
+                .book(bookRepository.findById(request.getBookId())
+                        .orElseThrow(() -> new BookNotFoundForIdException(request.getBookId())))
+                .quantity(request.getQuantity())
                 .build()));
     }
 

--- a/src/test/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailServiceUnitTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailServiceUnitTest.java
@@ -7,6 +7,7 @@ import com.t3t.bookstoreapi.shoppingcart.exception.ShoppingCartNotFoundForIdExce
 import com.t3t.bookstoreapi.shoppingcart.model.dto.ShoppingCartDetailDto;
 import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCart;
 import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCartDetail;
+import com.t3t.bookstoreapi.shoppingcart.model.request.ShoppingCartDetailCreationRequest;
 import com.t3t.bookstoreapi.shoppingcart.repository.ShoppingCartDetailRepository;
 import com.t3t.bookstoreapi.shoppingcart.repository.ShoppingCartRepository;
 import com.t3t.bookstoreapi.shoppingcart.service.ShoppingCartDetailService;
@@ -133,12 +134,18 @@ public class ShoppingCartDetailServiceUnitTest {
                 .quantity(testQuantity)
                 .build();
 
+        ShoppingCartDetailCreationRequest request = ShoppingCartDetailCreationRequest.builder()
+                .bookId(testBookId)
+                .quantity(testQuantity)
+                .build();
+
+
         Mockito.when(shoppingCartRepository.findById(testShoppingCartId)).thenReturn(Optional.of(testShoppingCart));
         Mockito.when(bookRepository.findById(testBookId)).thenReturn(Optional.of(testBook));
         Mockito.when(shoppingCartDetailRepository.save(Mockito.any(ShoppingCartDetail.class))).thenReturn(testShoppingCartDetail);
 
         // when
-        ShoppingCartDetailDto resultShoppingCartDetailDto = shoppingCartService.createShoppingCartDetail(testShoppingCartId, testBookId, testQuantity);
+        ShoppingCartDetailDto resultShoppingCartDetailDto = shoppingCartService.createShoppingCartDetail(testShoppingCartId, request);
 
         // then
         Assertions.assertEquals(testShoppingCartDetail.getId(), resultShoppingCartDetailDto.getId());
@@ -160,9 +167,14 @@ public class ShoppingCartDetailServiceUnitTest {
         long testBookId = 0L;
         long testQuantity = 0L;
 
+        ShoppingCartDetailCreationRequest request = ShoppingCartDetailCreationRequest.builder()
+                .bookId(testBookId)
+                .quantity(testQuantity)
+                .build();
+
         // when & then
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> shoppingCartService.createShoppingCartDetail(testShoppingCartId, testBookId, testQuantity));
+                () -> shoppingCartService.createShoppingCartDetail(testShoppingCartId, request));
     }
 
     /**

--- a/src/test/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailServiceUnitTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailServiceUnitTest.java
@@ -178,6 +178,51 @@ public class ShoppingCartDetailServiceUnitTest {
     }
 
     /**
+     * 장바구니 항목 수량 변경
+     * @see ShoppingCartDetailService#updateShoppingCartDetailQuantity
+     * @author wooody35545(구건모)
+     */
+    @Test
+    @DisplayName("장바구니 항목 수량 변경")
+    void updateShoppingCartDetailQuantity() {
+        // given
+        long testShoppingCartDetailId = 0L;
+        long testQuantity = 2L;
+
+        ShoppingCartDetail testShoppingCartDetail = ShoppingCartDetail.builder()
+                .id(testShoppingCartDetailId)
+                .quantity(1L)
+                .build();
+
+        Mockito.when(shoppingCartDetailRepository.findById(testShoppingCartDetailId)).thenReturn(Optional.of(testShoppingCartDetail));
+
+        // when
+        ShoppingCartDetailDto resultShoppingCartDetailDto = shoppingCartService.updateShoppingCartDetailQuantity(testShoppingCartDetailId, testQuantity);
+
+        // then
+        Assertions.assertEquals(testQuantity, resultShoppingCartDetailDto.getQuantity());
+    }
+
+    /**
+     * 장바구니 항목 수량 변경 - 존재하지 않는 장바구니 항목 식별자로 변경할 때 ShoppingCartDetailNotFoundForIdException 가 발생해야한다.
+     * @see ShoppingCartDetailService#updateShoppingCartDetailQuantity
+     * @author wooody35545(구건모)
+     */
+    @Test
+    @DisplayName("장바구니 항목 수량 변경 - 요청 파라미터의 수량이 0 이하일 때 IllegalArgumentException 이 발생해야한다.")
+    void updateShoppingCartDetailQuantityWithQuantityLessThanZero() {
+        // given
+        long testShoppingCartDetailId = 0L;
+        long testQuantity = 0L;
+
+        Mockito.when(shoppingCartDetailRepository.findById(testShoppingCartDetailId)).thenReturn(Optional.of(ShoppingCartDetail.builder().build()));
+
+        // when & then
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> shoppingCartService.updateShoppingCartDetailQuantity(testShoppingCartDetailId, testQuantity));
+    }
+
+    /**
      * 장바구니 항목 삭제
      * @see ShoppingCartDetailService#deleteShoppingCartDetail
      * @author wooody35545(구건모)

--- a/src/test/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailServiceUnitTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailServiceUnitTest.java
@@ -1,0 +1,100 @@
+package com.t3t.bookstoreapi.shoppingcart.service;
+
+import com.t3t.bookstoreapi.book.model.entity.Book;
+import com.t3t.bookstoreapi.shoppingcart.exception.ShoppingCartNotFoundForIdException;
+import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCart;
+import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCartDetail;
+import com.t3t.bookstoreapi.shoppingcart.repository.ShoppingCartDetailRepository;
+import com.t3t.bookstoreapi.shoppingcart.repository.ShoppingCartRepository;
+import com.t3t.bookstoreapi.shoppingcart.service.ShoppingCartDetailService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 장바구니 항목 서비스 단위 테스트
+ * @see ShoppingCartDetailService
+ */
+@ExtendWith(MockitoExtension.class)
+public class ShoppingCartDetailServiceUnitTest {
+    @Mock
+    ShoppingCartRepository shoppingCartRepository;
+    @Mock
+    ShoppingCartDetailRepository shoppingCartDetailRepository;
+
+    @InjectMocks
+    ShoppingCartDetailService shoppingCartService;
+
+    /**
+     * 장바구니 식별자로 전체 항목 리스트 조회
+     * @author wooody355(구건모)
+     */
+    @Test
+    @DisplayName("장바구니 식별자로 전체 항목 리스트 조회")
+    void getShoppingCartDetailList() {
+
+        // given
+        ShoppingCart testShoppingCart = ShoppingCart.builder()
+                .id(0L)
+                .build();
+
+        List<Book> testBookList = List.of(
+                Book.builder().bookId(1L).build(),
+                Book.builder().bookId(2L).build()
+        );
+
+        List<ShoppingCartDetail> shoppingCartDetailList = new ArrayList<>();
+
+        for (int i = 0; i < testBookList.size(); i++) {
+            shoppingCartDetailList.add(ShoppingCartDetail.builder()
+                    .id((long) i)
+                    .book(testBookList.get(0))
+                    .shoppingCart(testShoppingCart)
+                    .quantity(1L)
+                    .build()
+            );
+        }
+
+        Mockito.when(shoppingCartRepository.existsById(testShoppingCart.getId())).thenReturn(true);
+        Mockito.when(shoppingCartDetailRepository.findAllByShoppingCartId(testShoppingCart.getId())).thenReturn(shoppingCartDetailList);
+
+        // when
+        List<ShoppingCartDetail> resultShoppingCartDetailList
+                = shoppingCartService.getShoppingCartDetailList(testShoppingCart.getId());
+
+        // then
+        Assertions.assertFalse(resultShoppingCartDetailList.isEmpty());
+        Assertions.assertEquals(shoppingCartDetailList.size(), resultShoppingCartDetailList.size());
+
+        for(int i = 0; i < shoppingCartDetailList.size(); i++) {
+            Assertions.assertEquals(shoppingCartDetailList.get(i).getId(), resultShoppingCartDetailList.get(i).getId());
+            Assertions.assertEquals(shoppingCartDetailList.get(i).getBook(), resultShoppingCartDetailList.get(i).getBook());
+            Assertions.assertEquals(shoppingCartDetailList.get(i).getShoppingCart(), resultShoppingCartDetailList.get(i).getShoppingCart());
+            Assertions.assertEquals(shoppingCartDetailList.get(i).getQuantity(), resultShoppingCartDetailList.get(i).getQuantity());
+        }
+    }
+
+    /**
+     * 존재하지 않는 장바구니 식별자로 항목을 조회할 때 발생하면 ShoppingCartNotFoundForIdException 가 발생해야한다.
+     * @throws ShoppingCartNotFoundForIdException 장바구니 식별자가 존재하지 않을 때 발생하는 예외
+     * @author wooody35545(구건모)
+     */
+    @Test
+    @DisplayName("장바구니 항목 조회 - 존재하지 않는 장바구니 식별자")
+    void getShoppingCartDetailList_ShoppingCartNotFoundForIdException() {
+        // given
+        long testShoppingCartId = 0L;
+        Mockito.when(shoppingCartRepository.existsById(testShoppingCartId)).thenReturn(false);
+
+        // when & then
+        Assertions.assertThrows(ShoppingCartNotFoundForIdException.class,
+                () -> shoppingCartService.getShoppingCartDetailList(testShoppingCartId));
+    }
+}

--- a/src/test/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailServiceUnitTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/shoppingcart/service/ShoppingCartDetailServiceUnitTest.java
@@ -2,6 +2,7 @@ package com.t3t.bookstoreapi.shoppingcart.service;
 
 import com.t3t.bookstoreapi.book.model.entity.Book;
 import com.t3t.bookstoreapi.book.repository.BookRepository;
+import com.t3t.bookstoreapi.shoppingcart.exception.ShoppingCartDetailNotFoundForIdException;
 import com.t3t.bookstoreapi.shoppingcart.exception.ShoppingCartNotFoundForIdException;
 import com.t3t.bookstoreapi.shoppingcart.model.dto.ShoppingCartDetailDto;
 import com.t3t.bookstoreapi.shoppingcart.model.entity.ShoppingCart;
@@ -162,5 +163,46 @@ public class ShoppingCartDetailServiceUnitTest {
         // when & then
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> shoppingCartService.createShoppingCartDetail(testShoppingCartId, testBookId, testQuantity));
+    }
+
+    /**
+     * 장바구니 항목 삭제
+     * @see ShoppingCartDetailService#deleteShoppingCartDetail
+     * @author wooody35545(구건모)
+     */
+    @Test
+    @DisplayName("장바구니 항목 삭제")
+    void deleteShoppingCartDetail() {
+        // given
+        long testShoppingCartDetailId = 0L;
+
+        ShoppingCartDetail testShoppingCartDetail = ShoppingCartDetail.builder()
+                .id(testShoppingCartDetailId)
+                .build();
+
+        Mockito.when(shoppingCartDetailRepository.findById(testShoppingCartDetailId)).thenReturn(Optional.of(testShoppingCartDetail));
+
+        // when
+        shoppingCartService.deleteShoppingCartDetail(testShoppingCartDetailId);
+
+        // then
+        Mockito.verify(shoppingCartDetailRepository, Mockito.times(1)).delete(testShoppingCartDetail);
+    }
+
+    /**
+     * 장바구니 항목 삭제 - 존재하지 않는 장바구니 항목 식별자로 삭제할 때 ShoppingCartDetailNotFoundForIdException 가 발생해야한다.
+     * @throws ShoppingCartDetailNotFoundForIdException 장바구니 항목 식별자가 존재하지 않을 때 발생하는 예외
+     * @see ShoppingCartDetailService#deleteShoppingCartDetail
+     */
+    @Test
+    @DisplayName("장바구니 항목 삭제 - 존재하지 않는 장바구니 항목 식별자")
+    void deleteShoppingCartDetail_ShoppingCartDetailNotFoundForIdException() {
+        // given
+        long testShoppingCartDetailId = 0L;
+        Mockito.when(shoppingCartDetailRepository.findById(testShoppingCartDetailId)).thenReturn(Optional.empty());
+
+        // when & then
+        Assertions.assertThrows(ShoppingCartDetailNotFoundForIdException.class,
+                () -> shoppingCartService.deleteShoppingCartDetail(testShoppingCartDetailId));
     }
 }


### PR DESCRIPTION
**구현 내용**
- ShoppingCartController
  - [x] 장바구니 식별자로 장바구니에 포함된 모든 세부 항목 조회하는 API
  - [x] 장바구니 항목 추가 API
  - [x] 장바구니 항목 식별자로 삭제하는 API
  - [x] 장바구니 항목 식별자로 수량 변경하는 API

- ShoppingCartDetailService
  - [x] 장바구니 식별자로 특정 장바구니에 포함된 모든 상세 항목(ShoppingCartDetail) 조회
  - [x] 장바구니 항목 추가 기능
  - [x] 장바구니 항목 식별자로 삭제 기능
  - [x] 장바구니 항목 식별자로 수량 변경하는 기능

**테스트 내용**
- ShoppingCartDetailServiceUnitTest
  - 장바구니 식별자로 상세 항목 조회 단위 테스트
    - [x] 정상 상황 테스트
    - [x] 예외 상황 - 존재하지 않는 장바구니에 대한 조회 시도시 예외 발생 테스트

  - 장바구니 항목 추가 단위 테스트
    - [x] 정상 상황 테스트
    - [x] 예외 상황 - 장바구니 항목 추가 요청시 파라미터의 수량이 0 이하일 때

  - 장바구니 항목 수량 변경 단위 테스트
    - [x] 정상 상황 테스트
    - [x] 예외 상황 - 수량 변경 요청시 요청 파라미터의 수량이 0 이하일 때

  - 장바구니 항목 삭제 단위 테스트
    - [x] 정상 상황 테스트
    - [x] 예외 상황 - 존재하지 않는 장바구니 항목 식별자에 대한 삭제 요청