### PR TITLE
feature/member-entity - 회원 상태 및 역할 필드의 타입을 enum 으로 변경

### DIFF
--- a/src/main/java/com/t3t/bookstoreapi/member/model/constant/MemberRole.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/constant/MemberRole.java
@@ -1,0 +1,10 @@
+package com.t3t.bookstoreapi.member.model.constant;
+
+/**
+ * 회원의 역할을 나타내는 enum <br>
+ * 회원은 `USER(일반 사용자)`, `ADMIN(관리자)` 두 가지 역할을 가질 수 있다.
+ * @author woody35545(구건모)
+ */
+public enum MemberRole {
+    USER, ADMIN
+}

--- a/src/main/java/com/t3t/bookstoreapi/member/model/constant/MemberStatus.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/constant/MemberStatus.java
@@ -1,0 +1,10 @@
+package com.t3t.bookstoreapi.member.model.constant;
+
+/**
+ * 회원의 상태를 나타내는 enum <br>
+ * 회원은 `ACTIVE(활성)`, `INACTIVE(비활성)`, `WITHDRAWAL(탈퇴)` 세 가지 상태를 가질 수 있다.
+ * @author woody35545(구건모)
+ */
+public enum MemberStatus {
+    ACTIVE, INACTIVE, WITHDRAWAL
+}

--- a/src/main/java/com/t3t/bookstoreapi/member/model/entity/Member.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/entity/Member.java
@@ -1,5 +1,7 @@
 package com.t3t.bookstoreapi.member.model.entity;
 
+import com.t3t.bookstoreapi.member.model.constant.MemberRole;
+import com.t3t.bookstoreapi.member.model.constant.MemberStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -52,10 +54,12 @@ public class Member {
     private Long point;
 
     @Column(name = "member_status", length = 10, nullable = false)
+    @Enumerated(EnumType.STRING)
     @Comment("회원 상태")
-    private String status;
+    private MemberStatus status;
 
-    @Column(name = "member_role", columnDefinition = "TINYINT", nullable = false)
+    @Column(name = "member_role", length = 10, nullable = false)
+    @Enumerated(EnumType.STRING)
     @Comment("회원 역할")
-    private int role;
+    private MemberRole role;
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/model/entity/Member.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/entity/Member.java
@@ -27,7 +27,7 @@ public class Member {
     @ManyToOne
     @JoinColumn(name = "member_grade_id", nullable = false)
     @Comment("회원 등급 식별자")
-    private MemberGrade gradeId;
+    private MemberGrade grade;
 
     @Column(name = "member_name", length = 100, nullable = false)
     @Comment("회원 이름")

--- a/src/test/java/com/t3t/bookstoreapi/entity/BookRelatedEntityTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/entity/BookRelatedEntityTest.java
@@ -128,7 +128,7 @@ class BookRelatedEntityTest {
                 .phone("010-1234-5678")
                 .latestLogin(LocalDateTime.now())
                 .birthDate(LocalDateTime.now().toLocalDate())
-                .gradeId(memberGrade)
+                .grade(memberGrade)
                 .status(MemberStatus.ACTIVE)
                 .role(MemberRole.USER)
                 .build());

--- a/src/test/java/com/t3t/bookstoreapi/entity/BookRelatedEntityTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/entity/BookRelatedEntityTest.java
@@ -6,6 +6,8 @@ import com.t3t.bookstoreapi.booklike.model.entity.BookLike;
 import com.t3t.bookstoreapi.booklike.repository.BookLikeRepository;
 import com.t3t.bookstoreapi.category.model.entity.Category;
 import com.t3t.bookstoreapi.category.repository.CategoryRepository;
+import com.t3t.bookstoreapi.member.model.constant.MemberRole;
+import com.t3t.bookstoreapi.member.model.constant.MemberStatus;
 import com.t3t.bookstoreapi.member.model.entity.Member;
 import com.t3t.bookstoreapi.member.model.entity.MemberGrade;
 import com.t3t.bookstoreapi.member.model.entity.MemberGradePolicy;
@@ -127,8 +129,8 @@ class BookRelatedEntityTest {
                 .latestLogin(LocalDateTime.now())
                 .birthDate(LocalDateTime.now().toLocalDate())
                 .gradeId(memberGrade)
-                .status("ACTIVE")
-                .role(1)
+                .status(MemberStatus.ACTIVE)
+                .role(MemberRole.USER)
                 .build());
 
     }

--- a/src/test/java/com/t3t/bookstoreapi/member/MemberRelatedEntityTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/member/MemberRelatedEntityTest.java
@@ -135,7 +135,7 @@ class MemberRelatedEntityTest {
                 .phone("010-1234-5678")
                 .latestLogin(LocalDateTime.now())
                 .birthDate(LocalDateTime.now().toLocalDate())
-                .gradeId(memberGrade)
+                .grade(memberGrade)
                 .status(MemberStatus.ACTIVE)
                 .role(MemberRole.USER)
                 .build());
@@ -173,7 +173,7 @@ class MemberRelatedEntityTest {
                 .phone("010-1234-5678")
                 .latestLogin(LocalDateTime.now())
                 .birthDate(LocalDateTime.now().toLocalDate())
-                .gradeId(memberGrade)
+                .grade(memberGrade)
                 .status(MemberStatus.ACTIVE)
                 .role(MemberRole.USER)
                 .build());

--- a/src/test/java/com/t3t/bookstoreapi/member/MemberRelatedEntityTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/member/MemberRelatedEntityTest.java
@@ -1,5 +1,7 @@
 package com.t3t.bookstoreapi.member;
 
+import com.t3t.bookstoreapi.member.model.constant.MemberRole;
+import com.t3t.bookstoreapi.member.model.constant.MemberStatus;
 import com.t3t.bookstoreapi.member.model.entity.*;
 import com.t3t.bookstoreapi.member.repository.*;
 import lombok.extern.slf4j.Slf4j;
@@ -134,8 +136,8 @@ class MemberRelatedEntityTest {
                 .latestLogin(LocalDateTime.now())
                 .birthDate(LocalDateTime.now().toLocalDate())
                 .gradeId(memberGrade)
-                .status("ACTIVE")
-                .role(1)
+                .status(MemberStatus.ACTIVE)
+                .role(MemberRole.USER)
                 .build());
 
         // when
@@ -172,8 +174,8 @@ class MemberRelatedEntityTest {
                 .latestLogin(LocalDateTime.now())
                 .birthDate(LocalDateTime.now().toLocalDate())
                 .gradeId(memberGrade)
-                .status("ACTIVE")
-                .role(1)
+                .status(MemberStatus.ACTIVE)
+                .role(MemberRole.USER)
                 .build());
 
         Address address = addressRepository.save(Address.builder()

--- a/src/test/java/com/t3t/bookstoreapi/payment_test/EntityMappingTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/payment_test/EntityMappingTest.java
@@ -73,7 +73,7 @@ public class EntityMappingTest {
         order.setId(1L);
         order.setMember(Member.builder()
                 .id(1L)
-                .gradeId(memberGrade)
+                .grade(memberGrade)
                 .name("test")
                 .phone("010-1234-1234")
                 .email("g@naver.com")

--- a/src/test/java/com/t3t/bookstoreapi/payment_test/EntityMappingTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/payment_test/EntityMappingTest.java
@@ -1,5 +1,7 @@
 package com.t3t.bookstoreapi.payment_test;
 
+import com.t3t.bookstoreapi.member.model.constant.MemberRole;
+import com.t3t.bookstoreapi.member.model.constant.MemberStatus;
 import com.t3t.bookstoreapi.member.model.entity.Member;
 import com.t3t.bookstoreapi.member.model.entity.MemberGrade;
 import com.t3t.bookstoreapi.member.model.entity.MemberGradePolicy;
@@ -78,8 +80,8 @@ public class EntityMappingTest {
                 .birthDate(LocalDate.now())
                 .latestLogin(LocalDateTime.now())
                 .point(1L)
-                .status("test")
-                .role(1)
+                .status(MemberStatus.ACTIVE)
+                .role(MemberRole.USER)
                 .build());
         order.setDelivery(Delivery.builder()
                 .id(0L)

--- a/src/test/java/com/t3t/bookstoreapi/payment_test/PaymentTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/payment_test/PaymentTest.java
@@ -79,7 +79,7 @@ public class PaymentTest {
         order.setId(1L);
         order.setMember(Member.builder()
                         .id(1L)
-                .gradeId(memberGrade)
+                .grade(memberGrade)
                 .name("test")
                 .phone("010-1234-1234")
                 .email("g@naver.com")

--- a/src/test/java/com/t3t/bookstoreapi/payment_test/PaymentTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/payment_test/PaymentTest.java
@@ -1,5 +1,7 @@
 package com.t3t.bookstoreapi.payment_test;
 
+import com.t3t.bookstoreapi.member.model.constant.MemberRole;
+import com.t3t.bookstoreapi.member.model.constant.MemberStatus;
 import com.t3t.bookstoreapi.member.model.entity.Member;
 import com.t3t.bookstoreapi.member.model.entity.MemberGrade;
 import com.t3t.bookstoreapi.member.model.entity.MemberGradePolicy;
@@ -84,8 +86,8 @@ public class PaymentTest {
                 .birthDate(LocalDate.now())
                 .latestLogin(LocalDateTime.now())
                 .point(1L)
-                .status("test")
-                .role(1)
+                .status(MemberStatus.ACTIVE)
+                .role(MemberRole.USER)
                 .build());
         order.setDelivery(Delivery.builder()
                 .id(0L)


### PR DESCRIPTION
주요 내용

**`MemberStatus` 생성**
- 회원의 상태를 나타내는 enum 
- 회원은 `ACTIVE(활성)`, `INACTIVE(비활성)`, `WITHDRAWAL(탈퇴)` 세 가지 상태를 가질 수 있습니다.

**`MemberRole` 생성**
- 회원의 역할을 나타내는 enum
- 회원은 `USER(일반 사용자)`, `ADMIN(관리자)` 두 가지 역할을 가질 수 있습니다.

**`Member` 일부 필드 타입 변경**
- 기존에 String 으로 맵핑되어 있던 회원 상태 및 역할 필드를 각각 위의 두 enum 타입으로 변경

