### PR TITLE
feature/action-#124 - feature 브랜치에 push 시 테스트하는 workflow

### DIFF
--- a/.github/workflows/feature-test.yml
+++ b/.github/workflows/feature-test.yml
@@ -1,0 +1,26 @@
+name: CI-CD
+on:
+  push:
+    branches:
+      - 'releases/**'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    - name: Prepare secure key manager certKey file
+      run: |  
+        echo ${{ secrets.SECURE_KEY_MANAGER_CERT_KEY }} > t3team-skm-cert.txt
+        mkdir src/main/resources/key
+        base64 -d t3team-skm-cert.txt > src/main/resources/key/t3team-skm-cert.p12
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+        
+    - name: test with Maven
+      run: mvn test ${{ secrets.MAVEN_PACKAGE_OPTIONS }}


### PR DESCRIPTION
feature 브랜치에 push 할 때도 테스트가 진행되도록 workflow를 추가하였습니다. 

실제 테스트 코드 중 하나가 오류가 있어서 failure 라고 나오지만,
워크플로우의 테스트 과정은 정상적으로 동작하는 것 확인하였습니다.

![image](https://github.com/nhnacademy-be5-T3Team/bookstore-api/assets/84436996/caa6bf46-af19-46f9-aa5e-d60feb68c3c7)