### PR TITLE
feature/member #89 - 회원 조회

### DIFF
--- a/src/main/java/com/t3t/bookstoreapi/member/controller/MemberController.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/controller/MemberController.java
@@ -57,7 +57,7 @@ public class MemberController {
      * @author woody35545(구건모)
      * @see MemberAddressService#getMemberAddressListByMemberId(long)
      */
-    @GetMapping("/members/{memberId}/member-addresses")
+    @GetMapping("/members/{memberId}/addresses")
     @ResponseStatus(HttpStatus.OK)
     public BaseResponse<List<MemberAddressDto>> getMemberAddressListByMemberId(
             @PathVariable("memberId") long memberId) {

--- a/src/main/java/com/t3t/bookstoreapi/member/controller/MemberController.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.t3t.bookstoreapi.member.controller;
 
 import com.t3t.bookstoreapi.member.model.dto.MemberAddressDto;
+import com.t3t.bookstoreapi.member.model.dto.MemberDto;
 import com.t3t.bookstoreapi.member.model.request.MemberRegistrationRequest;
 import com.t3t.bookstoreapi.member.model.response.MemberRegistrationResponse;
 import com.t3t.bookstoreapi.member.service.MemberAddressService;
@@ -19,6 +20,18 @@ public class MemberController {
 
     private final MemberService memberService;
     private final MemberAddressService memberAddressService;
+
+    /**
+     * 회원 식별자로 특정 회원 정보를 조회하는 API
+     * @param memberId 조회하려는 회원의 식별자
+     * @author woody35545(구건모)
+     */
+    @GetMapping("/members/{memberId}")
+    @ResponseStatus(HttpStatus.OK)
+    public BaseResponse<MemberDto> getMemberById(@PathVariable("memberId") long memberId) {
+        return new BaseResponse<MemberDto>()
+                .data(memberService.getMemberById(memberId));
+    }
 
     /**
      * 회원 생성(가입) API
@@ -41,8 +54,8 @@ public class MemberController {
      * 회원 식별자로 특정 회원이 등록한 모든 회원 주소 정보들을 조회하는 API
      *
      * @param memberId 조회하려는 회원의 식별자
-     * @see MemberAddressService#getMemberAddressListByMemberId(long)
      * @author woody35545(구건모)
+     * @see MemberAddressService#getMemberAddressListByMemberId(long)
      */
     @GetMapping("/members/{memberId}/member-addresses")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/t3t/bookstoreapi/member/service/MemberService.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/service/MemberService.java
@@ -2,9 +2,12 @@ package com.t3t.bookstoreapi.member.service;
 
 import com.t3t.bookstoreapi.member.exception.AccountAlreadyExistsForIdException;
 import com.t3t.bookstoreapi.member.exception.MemberGradeNotFoundForNameException;
+import com.t3t.bookstoreapi.member.exception.MemberNotFoundException;
+import com.t3t.bookstoreapi.member.exception.MemberNotFoundForIdException;
 import com.t3t.bookstoreapi.member.model.constant.MemberGradeType;
 import com.t3t.bookstoreapi.member.model.constant.MemberRole;
 import com.t3t.bookstoreapi.member.model.constant.MemberStatus;
+import com.t3t.bookstoreapi.member.model.dto.MemberDto;
 import com.t3t.bookstoreapi.member.model.entity.BookstoreAccount;
 import com.t3t.bookstoreapi.member.model.entity.Member;
 import com.t3t.bookstoreapi.member.model.request.MemberRegistrationRequest;
@@ -21,12 +24,25 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class MemberService{
+public class MemberService {
     private final MemberRepository memberRepository;
     private final BookstoreAccountRepository bookstoreAccountRepository;
     private final AccountRepository accountRepository;
     private final MemberGradeRepository memberGradeRepository;
     private final BCryptPasswordEncoder passwordEncoder;
+
+    /**
+     * 회원 식별자로 회원 정보 조회
+     * @param memberId 조회하려는 회원 식별자
+     * @return 조회된 회원 정보 DTO
+     * @author woody35545(구건모)
+     */
+    @Transactional(readOnly = true)
+    public MemberDto getMemberById(Long memberId) {
+        return MemberDto.of(memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundForIdException(memberId)));
+    }
+
     /**
      * 회원 가입
      *


### PR DESCRIPTION
주문을 테스트하기 위해 단일 회원 조회하는 API 를 먼저 올립니다.

관리자 페이지와 관련된 회원 조회 API 는 테스트후 다시 올릴 예정입니다.

저번주에 인증이 구현되면서 header 에 토큰으로 회원 정보가 넘어 오기 때문에 URI 상에 식별자를 제거하는 것으로 결정되었으나,

ateway 나 auth 에 인증 관련 기능이 추가된지 얼마 안되었기 때문에 

front에서 gateway를 통해 bookstore로 요청이 전송될 때  토큰이 자동으로 요청에 포함되도록 하는 필터가 테스트되고 안정화 되기전까지는

문제가 생겨도 다른 기능 개발에 지장이 가지 않도록 우선은 기존처럼 path variable 에 식별자를 넣었습니다.
