### PR TITLE
feature/mypage-#138 마이페이지 회원 정보 관련 기능

### DIFF
--- a/src/main/java/com/t3t/bookstoreapi/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/t3t/bookstoreapi/common/exception/GlobalExceptionHandler.java
@@ -2,11 +2,7 @@ package com.t3t.bookstoreapi.common.exception;
 
 import com.t3t.bookstoreapi.book.exception.BookNotFoundException;
 import com.t3t.bookstoreapi.category.exception.CategoryNotFoundException;
-import com.t3t.bookstoreapi.member.exception.AccountAlreadyExistsException;
-import com.t3t.bookstoreapi.member.exception.MemberAddressCountLimitExceededException;
-import com.t3t.bookstoreapi.member.exception.MemberAddressNotFoundException;
-import com.t3t.bookstoreapi.member.exception.MemberGradeNotFoundForNameException;
-import com.t3t.bookstoreapi.member.exception.MemberNotFoundException;
+import com.t3t.bookstoreapi.member.exception.*;
 import com.t3t.bookstoreapi.model.response.BaseResponse;
 import com.t3t.bookstoreapi.order.exception.DeliveryNotFoundException;
 import com.t3t.bookstoreapi.order.exception.OrderStatusNotFoundException;
@@ -25,6 +21,19 @@ import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    /**
+     * 회원 계정의 비밀번호 검증 시, 비밀번호가 일치하지 않을 때 발생하는 예외 처리 핸들러
+     *
+     * @param accountPasswordNotMatchException 비밀번호가 일치하지 않을 때 발생하는 예외
+     * @return 401 UNAUTHORIZED - 예외 메시지 반환
+     * @author woody35545(구건모)
+     * @see com.t3t.bookstoreapi.member.exception.AccountPasswordNotMatchException
+     */
+    @ExceptionHandler(AccountPasswordNotMatchException.class)
+    public ResponseEntity<BaseResponse<Void>> handleAccountPasswordNotMatchException(AccountPasswordNotMatchException accountPasswordNotMatchException) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new BaseResponse<Void>().message(accountPasswordNotMatchException.getMessage()));
+    }
 
     /**
      * 주문 상태가 존재하지 않는 경우에 대한 예외 처리 핸들러
@@ -166,7 +175,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(new BaseResponse<Void>().message(unsupportedPaymentProviderTypeException.getMessage()));
     }
-    
+
     /**
      * 회원이 존재하지 않는 경우에 대한 예외 처리 핸들러
      * @param memberNotFoundException 회원이 존재하지 않는 경우 발생하는 예외

--- a/src/main/java/com/t3t/bookstoreapi/member/controller/MemberAddressController.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/controller/MemberAddressController.java
@@ -45,6 +45,7 @@ public class MemberAddressController {
 
     /**
      * 기본 주소 설정 및 변경 API
+     *
      * @author woody35545(구건모)
      */
     @PatchMapping("/member-addresses/{memberAddressId}/default")
@@ -58,6 +59,7 @@ public class MemberAddressController {
 
     /**
      * 회원 주소 삭제 API
+     *
      * @param memberAddressId 삭제할 회원 주소 식별자
      * @author woody35545(구건모)
      */
@@ -65,5 +67,18 @@ public class MemberAddressController {
     public BaseResponse<Void> deleteMemberAddress(@PathVariable("memberAddressId") long memberAddressId) {
         memberAddressService.deleteMemberAddress(memberAddressId);
         return new BaseResponse<Void>().message("주소가 삭제되었습니다.");
+    }
+
+    /**
+     * 회원 주소 별칭 변경 API
+     * @author woody35545(구건모)
+     */
+    @PatchMapping("/member-addresses/{memberAddressId}/nickname")
+    public BaseResponse<Void> modifyNickname(@PathVariable("memberAddressId") Long memberAddressId,
+                                             @RequestParam("newNickname") String newNickname) {
+
+        memberAddressService.modifyAddressNickname(memberAddressId, newNickname);
+
+        return new BaseResponse<Void>().message("주소 별칭이 변경되었습니다.");
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/controller/MemberAddressController.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/controller/MemberAddressController.java
@@ -41,4 +41,18 @@ public class MemberAddressController {
         return new BaseResponse<MemberAddressDto>()
                 .data(memberAddressService.createMemberAddress(request));
     }
+
+
+    /**
+     * 기본 주소 설정 및 변경 API
+     * @author woody35545(구건모)
+     */
+    @PatchMapping("/member-addresses/{memberAddressId}/default")
+    @ResponseStatus(HttpStatus.OK)
+    public BaseResponse<Void> modifyDefaultAddress(@PathVariable("memberAddressId") long memberAddressId) {
+
+        memberAddressService.modifyDefaultAddress(memberAddressId);
+
+        return new BaseResponse<Void>().message("기본 주소가 변경되었습니다.");
+    }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/controller/MemberAddressController.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/controller/MemberAddressController.java
@@ -55,4 +55,15 @@ public class MemberAddressController {
 
         return new BaseResponse<Void>().message("기본 주소가 변경되었습니다.");
     }
+
+    /**
+     * 회원 주소 삭제 API
+     * @param memberAddressId 삭제할 회원 주소 식별자
+     * @author woody35545(구건모)
+     */
+    @DeleteMapping("/member-addresses/{memberAddressId}")
+    public BaseResponse<Void> deleteMemberAddress(@PathVariable("memberAddressId") long memberAddressId) {
+        memberAddressService.deleteMemberAddress(memberAddressId);
+        return new BaseResponse<Void>().message("주소가 삭제되었습니다.");
+    }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/controller/MemberController.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.t3t.bookstoreapi.member.controller;
 import com.t3t.bookstoreapi.member.model.dto.MemberAddressDto;
 import com.t3t.bookstoreapi.member.model.dto.MemberDto;
 import com.t3t.bookstoreapi.member.model.request.MemberRegistrationRequest;
+import com.t3t.bookstoreapi.member.model.response.MemberInfoResponse;
 import com.t3t.bookstoreapi.member.model.response.MemberRegistrationResponse;
 import com.t3t.bookstoreapi.member.service.MemberAddressService;
 import com.t3t.bookstoreapi.member.service.MemberService;
@@ -23,14 +24,15 @@ public class MemberController {
 
     /**
      * 회원 식별자로 특정 회원 정보를 조회하는 API
+     *
      * @param memberId 조회하려는 회원의 식별자
      * @author woody35545(구건모)
      */
     @GetMapping("/members/{memberId}")
     @ResponseStatus(HttpStatus.OK)
-    public BaseResponse<MemberDto> getMemberById(@PathVariable("memberId") long memberId) {
-        return new BaseResponse<MemberDto>()
-                .data(memberService.getMemberById(memberId));
+    public BaseResponse<MemberInfoResponse> getMemberById(@PathVariable("memberId") long memberId) {
+        return new BaseResponse<MemberInfoResponse>()
+                .data(memberService.getMemberInfoResponseById(memberId));
     }
 
     /**

--- a/src/main/java/com/t3t/bookstoreapi/member/controller/MemberController.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.t3t.bookstoreapi.member.controller;
 
 import com.t3t.bookstoreapi.member.model.dto.MemberAddressDto;
 import com.t3t.bookstoreapi.member.model.dto.MemberDto;
+import com.t3t.bookstoreapi.member.model.request.MemberPasswordModifyRequest;
 import com.t3t.bookstoreapi.member.model.request.MemberRegistrationRequest;
 import com.t3t.bookstoreapi.member.model.response.MemberInfoResponse;
 import com.t3t.bookstoreapi.member.model.response.MemberRegistrationResponse;
@@ -66,5 +67,24 @@ public class MemberController {
 
         return new BaseResponse<List<MemberAddressDto>>()
                 .data(memberAddressService.getMemberAddressListByMemberId(memberId));
+    }
+
+    /**
+     * 회원 비밀번호 변경 API
+     *
+     * @param memberId 회원 식별자
+     * @param request  변경할 비밀번호 요청 정보
+     * @return 200 OK - 비밀번호 변경 성공 메시지
+     * @author woody35545(구건모)
+     * @see MemberService#modifyMemberPassword(long, MemberPasswordModifyRequest)
+     */
+    @PatchMapping("/members/{memberId}")
+    @ResponseStatus(HttpStatus.OK)
+    public BaseResponse<Void> modifyMemberPassword(@PathVariable("memberId") long memberId,
+                                                   @RequestBody MemberPasswordModifyRequest request) {
+
+        memberService.modifyMemberPassword(memberId, request);
+
+        return new BaseResponse<Void>().message("비밀번호가 변경되었습니다.");
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/controller/MemberController.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/controller/MemberController.java
@@ -1,7 +1,6 @@
 package com.t3t.bookstoreapi.member.controller;
 
 import com.t3t.bookstoreapi.member.model.dto.MemberAddressDto;
-import com.t3t.bookstoreapi.member.model.dto.MemberDto;
 import com.t3t.bookstoreapi.member.model.request.MemberPasswordModifyRequest;
 import com.t3t.bookstoreapi.member.model.request.MemberRegistrationRequest;
 import com.t3t.bookstoreapi.member.model.response.MemberInfoResponse;
@@ -86,5 +85,16 @@ public class MemberController {
         memberService.modifyMemberPassword(memberId, request);
 
         return new BaseResponse<Void>().message("비밀번호가 변경되었습니다.");
+    }
+
+    /**
+     * 회원 탈퇴 처리 API
+     *
+     */
+    @DeleteMapping("/members/{memberId}")
+    @ResponseStatus(HttpStatus.OK)
+    public BaseResponse<Void> withdrawMember(@PathVariable("memberId") long memberId) {
+        memberService.withdrawMember(memberId);
+        return new BaseResponse<Void>().message("회원 탈퇴가 완료되었습니다.");
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/controller/MemberController.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/controller/MemberController.java
@@ -81,7 +81,7 @@ public class MemberController {
     @PatchMapping("/members/{memberId}")
     @ResponseStatus(HttpStatus.OK)
     public BaseResponse<Void> modifyMemberPassword(@PathVariable("memberId") long memberId,
-                                                   @RequestBody MemberPasswordModifyRequest request) {
+                                                   @Valid @RequestBody MemberPasswordModifyRequest request) {
 
         memberService.modifyMemberPassword(memberId, request);
 

--- a/src/main/java/com/t3t/bookstoreapi/member/exception/AccountPasswordNotMatchException.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/exception/AccountPasswordNotMatchException.java
@@ -1,0 +1,11 @@
+package com.t3t.bookstoreapi.member.exception;
+
+/**
+ * 회원 계정의 비밀번호 검증 시, 비밀번호가 일치하지 않을 때 발생하는 예외
+ * @author woody35545(구건모)
+ */
+public class AccountPasswordNotMatchException extends RuntimeException {
+    public AccountPasswordNotMatchException() {
+        super("비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/member/model/dto/MemberAddressDto.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/dto/MemberAddressDto.java
@@ -10,7 +10,7 @@ import lombok.*;
  */
 @Data
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberAddressDto {
     private Long id;

--- a/src/main/java/com/t3t/bookstoreapi/member/model/dto/MemberAddressDto.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/dto/MemberAddressDto.java
@@ -5,12 +5,13 @@ import lombok.*;
 
 /**
  * 회원 주소 정보에 대한 DTO
+ *
  * @author woody35545(구건모)
  */
 @Data
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberAddressDto {
     private Long id;
     private Long memberId;
@@ -18,6 +19,7 @@ public class MemberAddressDto {
     private String roadNameAddress;
     private String addressNickname;
     private String addressDetail;
+    private Boolean isDefaultAddress;
 
     public static MemberAddressDto of(MemberAddress memberAddress) {
         return MemberAddressDto.builder()
@@ -26,6 +28,7 @@ public class MemberAddressDto {
                 .addressNumber(memberAddress.getAddress().getAddressNumber())
                 .roadNameAddress(memberAddress.getAddress().getRoadNameAddress())
                 .addressNickname(memberAddress.getAddressNickname())
-                .addressDetail(memberAddress.getAddressDetail()).build();
+                .addressDetail(memberAddress.getAddressDetail())
+                .isDefaultAddress(memberAddress.getIsDefaultAddress()).build();
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/model/entity/Account.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/entity/Account.java
@@ -33,4 +33,12 @@ public class Account {
     @Column(name = "deleted", columnDefinition = "TINYINT(1) DEFAULT 0", nullable = false)
     @Comment("삭제 여부")
     private boolean deleted;
+
+    /**
+     * 계정 삭제 (soft delete)
+     * @author woody35545
+     */
+    public void delete() {
+        this.deleted = true;
+    }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/model/entity/BookstoreAccount.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/entity/BookstoreAccount.java
@@ -19,4 +19,8 @@ public class BookstoreAccount extends Account {
     public BookstoreAccount(String accountPassword) {
         AccountPassword = accountPassword;
     }
+
+    public void modifyPassword(String newPassword) {
+        this.AccountPassword = newPassword;
+    }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/model/entity/Member.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/entity/Member.java
@@ -62,4 +62,8 @@ public class Member {
     @Enumerated(EnumType.STRING)
     @Comment("회원 역할")
     private MemberRole role;
+
+    public void withdraw() {
+        this.status = MemberStatus.WITHDRAWAL;
+    }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/model/entity/MemberAddress.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/entity/MemberAddress.java
@@ -39,4 +39,21 @@ public class MemberAddress {
     @Column(name = "default_address", columnDefinition = "TINYINT(1)", nullable = false)
     @Comment("기본 주소 여부")
     private Boolean isDefaultAddress;
+
+    /**
+     * 기본 주소 설정을 한다.
+     * @author woody35545(구건모)
+     */
+    public void asDefaultAddress() {
+        this.isDefaultAddress = true;
+    }
+
+    /**
+     * 기본 주소 설정을 해제한다.
+     * @author woody35545(구건모)
+     */
+    public void asNonDefaultAddress() {
+        this.isDefaultAddress = false;
+    }
+
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/model/entity/MemberAddress.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/entity/MemberAddress.java
@@ -4,6 +4,7 @@ import lombok.*;
 import org.hibernate.annotations.Comment;
 
 import javax.persistence.*;
+
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -42,6 +43,7 @@ public class MemberAddress {
 
     /**
      * 기본 주소 설정을 한다.
+     *
      * @author woody35545(구건모)
      */
     public void asDefaultAddress() {
@@ -50,10 +52,18 @@ public class MemberAddress {
 
     /**
      * 기본 주소 설정을 해제한다.
+     *
      * @author woody35545(구건모)
      */
     public void asNonDefaultAddress() {
         this.isDefaultAddress = false;
     }
 
+    /**
+     * 주소 별칭을 변경한다.
+     * author woody35545(구건모)
+     */
+    public void modifyNickname(String addressNickname) {
+        this.addressNickname = addressNickname;
+    }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/model/entity/MemberAddress.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/entity/MemberAddress.java
@@ -35,4 +35,8 @@ public class MemberAddress {
     @Column(name = "member_address_detail", length = 100, nullable = false)
     @Comment("상세 주소")
     private String addressDetail;
+
+    @Column(name = "default_address", columnDefinition = "TINYINT(1)", nullable = false)
+    @Comment("기본 주소 여부")
+    private Boolean isDefaultAddress;
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/model/request/MemberPasswordModifyRequest.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/request/MemberPasswordModifyRequest.java
@@ -2,6 +2,8 @@ package com.t3t.bookstoreapi.member.model.request;
 
 import lombok.*;
 
+import javax.validation.constraints.NotBlank;
+
 /**
  * 회원 비밀번호 수정 요청 객체
  *
@@ -12,6 +14,8 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberPasswordModifyRequest {
+    @NotBlank(message = "현재 비밀번호가 누락되었습니다.")
     private String currentPassword;
+    @NotBlank(message = "새로운 비밀번호가 누락되었습니다.")
     private String newPassword;
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/model/request/MemberPasswordModifyRequest.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/request/MemberPasswordModifyRequest.java
@@ -1,0 +1,17 @@
+package com.t3t.bookstoreapi.member.model.request;
+
+import lombok.*;
+
+/**
+ * 회원 비밀번호 수정 요청 객체
+ *
+ * @author woody35545(구건모)
+ */
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberPasswordModifyRequest {
+    private String currentPassword;
+    private String newPassword;
+}

--- a/src/main/java/com/t3t/bookstoreapi/member/model/response/MemberInfoResponse.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/response/MemberInfoResponse.java
@@ -1,0 +1,39 @@
+package com.t3t.bookstoreapi.member.model.response;
+
+import com.t3t.bookstoreapi.member.model.constant.MemberRole;
+import com.t3t.bookstoreapi.member.model.constant.MemberStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 회원과 관련된 정보를 종합적으로 담기 위한 응답 클래스
+ *
+ * @author woody35545(구건모)
+ * @see com.t3t.bookstoreapi.member.model.entity.Member
+ * @see com.t3t.bookstoreapi.member.model.entity.MemberGrade
+ * @see com.t3t.bookstoreapi.member.model.entity.Account
+ */
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberInfoResponse {
+    private String accountId;
+    private Long memberId;
+    private String name;
+    private String phone;
+    private String email;
+    private LocalDate birthDate;
+    private LocalDateTime latestLogin;
+    private Long point;
+    private Integer gradeId;
+    private String gradeName;
+    private MemberStatus status;
+    private MemberRole role;
+}

--- a/src/main/java/com/t3t/bookstoreapi/member/repository/AccountRepository.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/repository/AccountRepository.java
@@ -3,6 +3,9 @@ package com.t3t.bookstoreapi.member.repository;
 import com.t3t.bookstoreapi.member.model.entity.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AccountRepository extends JpaRepository<Account, String> {
     boolean existsAccountById(String id);
+    Optional<Account> findByMemberId(long memberId);
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/repository/BookstoreAccountRepository.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/repository/BookstoreAccountRepository.java
@@ -3,5 +3,8 @@ package com.t3t.bookstoreapi.member.repository;
 import com.t3t.bookstoreapi.member.model.entity.BookstoreAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BookstoreAccountRepository extends JpaRepository<BookstoreAccount, String> {
+    Optional<BookstoreAccount> findByMemberId(long memberId);
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/repository/MemberAddressRepository.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/repository/MemberAddressRepository.java
@@ -3,6 +3,9 @@ package com.t3t.bookstoreapi.member.repository;
 import com.t3t.bookstoreapi.member.model.entity.MemberAddress;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MemberAddressRepository extends JpaRepository<MemberAddress, Long>, MemberAddressRepositoryCustom {
     int countByMemberId(long memberId);
+    List<MemberAddress> findByMemberId(long memberId);
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/repository/MemberAddressRepository.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/repository/MemberAddressRepository.java
@@ -7,5 +7,6 @@ import java.util.List;
 
 public interface MemberAddressRepository extends JpaRepository<MemberAddress, Long>, MemberAddressRepositoryCustom {
     int countByMemberId(long memberId);
+    boolean existsByAddressId(long addressId);
     List<MemberAddress> findByMemberId(long memberId);
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/repository/MemberAddressRepositoryCustomImpl.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/repository/MemberAddressRepositoryCustomImpl.java
@@ -42,6 +42,7 @@ public class MemberAddressRepositoryCustomImpl implements MemberAddressRepositor
 
     /**
      * {@inheritDoc}
+     *
      * @author woody35545(구건모)
      */
     @Override
@@ -53,7 +54,8 @@ public class MemberAddressRepositoryCustomImpl implements MemberAddressRepositor
                         memberAddress.address.addressNumber,
                         memberAddress.address.roadNameAddress,
                         memberAddress.addressDetail,
-                        memberAddress.addressNickname))
+                        memberAddress.addressNickname,
+                        memberAddress.isDefaultAddress))
                 .from(memberAddress)
                 .where(memberAddress.member.id.eq(memberId))
                 .fetch();

--- a/src/main/java/com/t3t/bookstoreapi/member/repository/MemberRepository.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/repository/MemberRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom{
     List<Member> findByName(String name);
     Optional<Member> findById(Long memberId);
 

--- a/src/main/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.t3t.bookstoreapi.member.repository;
+
+import com.t3t.bookstoreapi.member.model.response.MemberInfoResponse;
+
+/**
+ * Member 엔티티에 대한 커스텀 쿼리를 정의하기 위한 인터페이스
+ * @author woody35545(구건모)
+ */
+public interface MemberRepositoryCustom {
+    /**
+     * 회원 식별자로 회원 정보를 조회한다.
+     * @param memberId 조회하려는 회원의 식별자
+     * @return 조회된 회원 정보
+     */
+    MemberInfoResponse getMemberInfoResponseByMemberId(long memberId);
+}

--- a/src/main/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryCustom.java
@@ -2,6 +2,8 @@ package com.t3t.bookstoreapi.member.repository;
 
 import com.t3t.bookstoreapi.member.model.response.MemberInfoResponse;
 
+import java.util.Optional;
+
 /**
  * Member 엔티티에 대한 커스텀 쿼리를 정의하기 위한 인터페이스
  * @author woody35545(구건모)
@@ -12,5 +14,5 @@ public interface MemberRepositoryCustom {
      * @param memberId 조회하려는 회원의 식별자
      * @return 조회된 회원 정보
      */
-    MemberInfoResponse getMemberInfoResponseByMemberId(long memberId);
+    Optional<MemberInfoResponse> getMemberInfoResponseByMemberId(long memberId);
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryCustomImpl.java
@@ -1,0 +1,44 @@
+package com.t3t.bookstoreapi.member.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.t3t.bookstoreapi.member.model.response.MemberInfoResponse;
+import lombok.RequiredArgsConstructor;
+
+import static com.t3t.bookstoreapi.member.model.entity.QAccount.account;
+import static com.t3t.bookstoreapi.member.model.entity.QMember.member;
+
+@RequiredArgsConstructor
+public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 회원 식별자로 회원의 정보를 조회한다.
+     *
+     * @param memberId 조회하려는 회원의 식별자
+     * @author woody35545
+     * @see MemberInfoResponse
+     */
+    @Override
+    public MemberInfoResponse getMemberInfoResponseByMemberId(long memberId) {
+        return queryFactory.select(Projections.bean(
+                        MemberInfoResponse.class,
+                        member.id.as("memberId"),
+                        member.name.as("name"),
+                        member.phone.as("phone"),
+                        member.email.as("email"),
+                        member.birthDate.as("birthDate"),
+                        member.latestLogin.as("latestLogin"),
+                        member.point.as("point"),
+                        member.grade.gradeId.as("gradeId"),
+                        member.grade.name.as("gradeName"),
+                        member.status.as("status"),
+                        member.role.as("role"),
+                        account.id.as("accountId")))
+                .from(member)
+                .join(account).on(member.eq(account.member))
+                .where(member.id.eq(memberId))
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryCustomImpl.java
@@ -5,6 +5,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.t3t.bookstoreapi.member.model.response.MemberInfoResponse;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Optional;
+
 import static com.t3t.bookstoreapi.member.model.entity.QAccount.account;
 import static com.t3t.bookstoreapi.member.model.entity.QMember.member;
 
@@ -21,24 +23,24 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
      * @see MemberInfoResponse
      */
     @Override
-    public MemberInfoResponse getMemberInfoResponseByMemberId(long memberId) {
-        return queryFactory.select(Projections.bean(
-                        MemberInfoResponse.class,
-                        member.id.as("memberId"),
-                        member.name.as("name"),
-                        member.phone.as("phone"),
-                        member.email.as("email"),
-                        member.birthDate.as("birthDate"),
-                        member.latestLogin.as("latestLogin"),
-                        member.point.as("point"),
-                        member.grade.gradeId.as("gradeId"),
-                        member.grade.name.as("gradeName"),
-                        member.status.as("status"),
-                        member.role.as("role"),
-                        account.id.as("accountId")))
-                .from(member)
-                .join(account).on(member.eq(account.member))
-                .where(member.id.eq(memberId))
-                .fetchOne();
+    public Optional<MemberInfoResponse> getMemberInfoResponseByMemberId(long memberId) {
+        return Optional.ofNullable(
+                queryFactory.select(Projections.bean(MemberInfoResponse.class,
+                                member.id.as("memberId"),
+                                member.name.as("name"),
+                                member.phone.as("phone"),
+                                member.email.as("email"),
+                                member.birthDate.as("birthDate"),
+                                member.latestLogin.as("latestLogin"),
+                                member.point.as("point"),
+                                member.grade.gradeId.as("gradeId"),
+                                member.grade.name.as("gradeName"),
+                                member.status.as("status"),
+                                member.role.as("role"),
+                                account.id.as("accountId")))
+                        .from(member)
+                        .join(account).on(member.eq(account.member))
+                        .where(member.id.eq(memberId))
+                        .fetchOne());
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/service/MemberAddressService.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/service/MemberAddressService.java
@@ -108,4 +108,23 @@ public class MemberAddressService {
 
         memberAddress.asDefaultAddress();
     }
+
+    /**
+     * 회원 주소 삭제
+     *
+     * @param memberAddressId 삭제할 회원 주소 식별자
+     * @author woody35545(구건모)
+     */
+    public void deleteMemberAddress(long memberAddressId) {
+        MemberAddress memberAddress = memberAddressRepository.findById(memberAddressId)
+                .orElseThrow(() -> new MemberAddressNotFoundForIdException(memberAddressId));
+
+        long addressId = memberAddress.getAddress().getId();
+
+        memberAddressRepository.delete(memberAddress);
+
+        if (!memberAddressRepository.existsByAddressId(addressId)) {
+            addressRepository.delete(memberAddress.getAddress());
+        }
+    }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/service/MemberAddressService.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/service/MemberAddressService.java
@@ -67,7 +67,7 @@ public class MemberAddressService {
         Member member = memberRepository.findById(request.getMemberId())
                 .orElseThrow(() -> new MemberNotFoundForIdException(request.getMemberId()));
 
-        if(memberAddressRepository.countByMemberId(member.getId()) >= MAX_MEMBER_ADDRESS_COUNT) {
+        if (memberAddressRepository.countByMemberId(member.getId()) >= MAX_MEMBER_ADDRESS_COUNT) {
             throw new MemberAddressCountLimitExceededException();
         }
 
@@ -82,6 +82,7 @@ public class MemberAddressService {
                 .member(member)
                 .addressNickname(request.getAddressNickname())
                 .addressDetail(request.getAddressDetail())
+                .isDefaultAddress(false)
                 .build());
 
         return MemberAddressDto.of(memberAddress);

--- a/src/main/java/com/t3t/bookstoreapi/member/service/MemberAddressService.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/service/MemberAddressService.java
@@ -87,4 +87,25 @@ public class MemberAddressService {
 
         return MemberAddressDto.of(memberAddress);
     }
+
+
+    /**
+     * 기본 주소 설정 및 변경
+     *
+     * @param memberAddressId 기본 주소로 설정할 회원 주소 식별자
+     * @author woody35545(구건모)
+     */
+    public void modifyDefaultAddress(long memberAddressId) {
+        MemberAddress memberAddress = memberAddressRepository.findById(memberAddressId)
+                .orElseThrow(() -> new MemberAddressNotFoundForIdException(memberAddressId));
+
+        if (memberAddress.getIsDefaultAddress()) {
+            return;
+        }
+
+        memberAddressRepository.findByMemberId(memberAddress.getMember().getId()).stream()
+                .forEach(address -> address.asNonDefaultAddress());
+
+        memberAddress.asDefaultAddress();
+    }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/service/MemberAddressService.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/service/MemberAddressService.java
@@ -127,4 +127,15 @@ public class MemberAddressService {
             addressRepository.delete(memberAddress.getAddress());
         }
     }
+
+    /**
+     * 주소 별칭 변경
+     * author woody35545(구건모)
+     */
+    public void modifyAddressNickname(long memberAddressId, String addressNickname) {
+        MemberAddress memberAddress = memberAddressRepository.findById(memberAddressId)
+                .orElseThrow(() -> new MemberAddressNotFoundForIdException(memberAddressId));
+
+        memberAddress.modifyNickname(addressNickname);
+    }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/service/MemberService.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/service/MemberService.java
@@ -2,15 +2,14 @@ package com.t3t.bookstoreapi.member.service;
 
 import com.t3t.bookstoreapi.member.exception.AccountAlreadyExistsForIdException;
 import com.t3t.bookstoreapi.member.exception.MemberGradeNotFoundForNameException;
-import com.t3t.bookstoreapi.member.exception.MemberNotFoundException;
 import com.t3t.bookstoreapi.member.exception.MemberNotFoundForIdException;
 import com.t3t.bookstoreapi.member.model.constant.MemberGradeType;
 import com.t3t.bookstoreapi.member.model.constant.MemberRole;
 import com.t3t.bookstoreapi.member.model.constant.MemberStatus;
-import com.t3t.bookstoreapi.member.model.dto.MemberDto;
 import com.t3t.bookstoreapi.member.model.entity.BookstoreAccount;
 import com.t3t.bookstoreapi.member.model.entity.Member;
 import com.t3t.bookstoreapi.member.model.request.MemberRegistrationRequest;
+import com.t3t.bookstoreapi.member.model.response.MemberInfoResponse;
 import com.t3t.bookstoreapi.member.model.response.MemberRegistrationResponse;
 import com.t3t.bookstoreapi.member.repository.AccountRepository;
 import com.t3t.bookstoreapi.member.repository.BookstoreAccountRepository;
@@ -38,9 +37,9 @@ public class MemberService {
      * @author woody35545(구건모)
      */
     @Transactional(readOnly = true)
-    public MemberDto getMemberById(Long memberId) {
-        return MemberDto.of(memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundForIdException(memberId)));
+    public MemberInfoResponse getMemberInfoResponseById(Long memberId) {
+        return memberRepository.getMemberInfoResponseByMemberId(memberId)
+                .orElseThrow(() -> new MemberNotFoundForIdException(memberId));
     }
 
     /**

--- a/src/main/java/com/t3t/bookstoreapi/member/service/MemberService.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/service/MemberService.java
@@ -6,6 +6,7 @@ import com.t3t.bookstoreapi.member.exception.MemberNotFoundForIdException;
 import com.t3t.bookstoreapi.member.model.constant.MemberGradeType;
 import com.t3t.bookstoreapi.member.model.constant.MemberRole;
 import com.t3t.bookstoreapi.member.model.constant.MemberStatus;
+import com.t3t.bookstoreapi.member.model.entity.Account;
 import com.t3t.bookstoreapi.member.model.entity.BookstoreAccount;
 import com.t3t.bookstoreapi.member.model.entity.Member;
 import com.t3t.bookstoreapi.member.model.request.MemberPasswordModifyRequest;
@@ -93,5 +94,24 @@ public class MemberService {
         }
 
         bookstoreAccount.modifyPassword(passwordEncoder.encode(request.getNewPassword()));
+    }
+
+    /**
+     * 회원 탈퇴
+     *
+     * @param memberId 탈퇴하려는 회원 식별자
+     * @throws MemberNotFoundForIdException 회원 식별자에 해당하는 회원이 존재하지 않을 경우 발생
+     */
+    public void withdrawalMember(long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundForIdException(memberId));
+
+        Account account = accountRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new MemberNotFoundForIdException(memberId));
+
+        account.delete();
+        
+        member.withdraw();
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/service/MemberService.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/service/MemberService.java
@@ -8,6 +8,7 @@ import com.t3t.bookstoreapi.member.model.constant.MemberRole;
 import com.t3t.bookstoreapi.member.model.constant.MemberStatus;
 import com.t3t.bookstoreapi.member.model.entity.BookstoreAccount;
 import com.t3t.bookstoreapi.member.model.entity.Member;
+import com.t3t.bookstoreapi.member.model.request.MemberPasswordModifyRequest;
 import com.t3t.bookstoreapi.member.model.request.MemberRegistrationRequest;
 import com.t3t.bookstoreapi.member.model.response.MemberInfoResponse;
 import com.t3t.bookstoreapi.member.model.response.MemberRegistrationResponse;
@@ -32,6 +33,7 @@ public class MemberService {
 
     /**
      * 회원 식별자로 회원 정보 조회
+     *
      * @param memberId 조회하려는 회원 식별자
      * @return 조회된 회원 정보 DTO
      * @author woody35545(구건모)
@@ -74,5 +76,22 @@ public class MemberService {
                 .build());
 
         return MemberRegistrationResponse.of(bookstoreAccount.getId(), member);
+    }
+
+    /**
+     * 회원 비밀번호 변경<br>
+     * 기존 비밀번호를 검증하고 변경할 비밀번호를 받아 회원 계정의 비밀번호를 변경한다.
+     *
+     * @author woody35545(구건모)
+     */
+    public void modifyMemberPassword(long memberId, MemberPasswordModifyRequest request) {
+        BookstoreAccount bookstoreAccount = bookstoreAccountRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new MemberNotFoundForIdException(memberId));
+
+        if (!passwordEncoder.matches(request.getCurrentPassword(), bookstoreAccount.getAccountPassword())) {
+            throw new IllegalArgumentException("기존 비밀번호가 일치하지 않습니다.");
+        }
+
+        bookstoreAccount.modifyPassword(passwordEncoder.encode(request.getNewPassword()));
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/service/MemberService.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/service/MemberService.java
@@ -102,7 +102,7 @@ public class MemberService {
      * @param memberId 탈퇴하려는 회원 식별자
      * @throws MemberNotFoundForIdException 회원 식별자에 해당하는 회원이 존재하지 않을 경우 발생
      */
-    public void withdrawalMember(long memberId) {
+    public void withdrawMember(long memberId) {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundForIdException(memberId));
@@ -111,7 +111,7 @@ public class MemberService {
                 .orElseThrow(() -> new MemberNotFoundForIdException(memberId));
 
         account.delete();
-        
+
         member.withdraw();
     }
 }

--- a/src/test/java/com/t3t/bookstoreapi/member/model/entity/MemberRelatedEntityTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/member/model/entity/MemberRelatedEntityTest.java
@@ -188,14 +188,17 @@ class MemberRelatedEntityTest {
                 .address(address)
                 .addressDetail("test")
                 .addressNickname("test")
+                .isDefaultAddress(true)
                 .build());
 
         // when
-        Optional<MemberAddress> resultMemberAddress = memberAddressRepository.findById(memberAddress.getId());
+        Optional<MemberAddress> optMemberAddress = memberAddressRepository.findById(memberAddress.getId());
 
         // then
-        Assertions.assertTrue(resultMemberAddress.isPresent());
-        Assertions.assertEquals(memberAddress, resultMemberAddress.get());
+        Assertions.assertTrue(optMemberAddress.isPresent());
+        MemberAddress resultMemberAddress = optMemberAddress.get();
+
+        Assertions.assertEquals(memberAddress, resultMemberAddress);
 
     }
 }

--- a/src/test/java/com/t3t/bookstoreapi/member/repository/MemberAddressRepositoryTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/member/repository/MemberAddressRepositoryTest.java
@@ -85,6 +85,7 @@ public class MemberAddressRepositoryTest {
                 .address(testAddress)
                 .addressDetail("test")
                 .addressNickname("test")
+                .isDefaultAddress(true)
                 .build());
 
         // when
@@ -150,6 +151,7 @@ public class MemberAddressRepositoryTest {
                     .address(testAddress)
                     .addressDetail("testAddressDetail" + i)
                     .addressNickname("testAddressNickname" + i)
+                    .isDefaultAddress(true)
                     .build()));
         }
 

--- a/src/test/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,103 @@
+package com.t3t.bookstoreapi.member.repository;
+
+import com.t3t.bookstoreapi.config.DataSourceConfig;
+import com.t3t.bookstoreapi.config.DatabasePropertiesConfig;
+import com.t3t.bookstoreapi.config.QueryDslConfig;
+import com.t3t.bookstoreapi.config.RestTemplateConfig;
+import com.t3t.bookstoreapi.keymanager.service.SecretKeyManagerService;
+import com.t3t.bookstoreapi.member.model.constant.MemberRole;
+import com.t3t.bookstoreapi.member.model.constant.MemberStatus;
+import com.t3t.bookstoreapi.member.model.entity.Account;
+import com.t3t.bookstoreapi.member.model.entity.Member;
+import com.t3t.bookstoreapi.member.model.entity.MemberGrade;
+import com.t3t.bookstoreapi.member.model.entity.MemberGradePolicy;
+import com.t3t.bookstoreapi.member.model.response.MemberInfoResponse;
+import com.t3t.bookstoreapi.property.SecretKeyManagerProperties;
+import com.t3t.bookstoreapi.property.SecretKeyProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({DataSourceConfig.class, DatabasePropertiesConfig.class,
+        QueryDslConfig.class, RestTemplateConfig.class,
+        SecretKeyManagerService.class, SecretKeyManagerProperties.class, SecretKeyProperties.class})
+class MemberRepositoryTest {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MemberGradePolicyRepository memberGradePolicyRepository;
+
+    @Autowired
+    private MemberGradeRepository memberGradeRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    /**
+     * 회원 식별자로 회원 정보 조회하는 Custom Repository(QueryDSL) 메서드 테스트
+     *
+     * @see MemberRepository#getMemberInfoResponseByMemberId(long)
+     */
+    @Test
+    @DisplayName("회원 식별자로 회원 정보 조회")
+    void getMemberInfoResponseByMemberIdTest() {
+        // given
+        MemberGradePolicy memberGradePolicy = memberGradePolicyRepository.save(MemberGradePolicy.builder()
+                .startAmount(BigDecimal.valueOf(0))
+                .endAmount(BigDecimal.valueOf(100000))
+                .build());
+
+        MemberGrade memberGrade = memberGradeRepository.save(MemberGrade.builder()
+                .policy(memberGradePolicy)
+                .name("test")
+                .build());
+
+        Member member = memberRepository.save(Member.builder()
+                .name("test")
+                .email("woody@mail.com")
+                .point(1000L)
+                .phone("010-1234-5678")
+                .latestLogin(LocalDateTime.now())
+                .birthDate(LocalDateTime.now().toLocalDate())
+                .grade(memberGrade)
+                .status(MemberStatus.ACTIVE)
+                .role(MemberRole.USER)
+                .build());
+
+        Account account = accountRepository.save(Account.builder()
+                .member(member)
+                .id("test")
+                .build());
+
+        // when
+        MemberInfoResponse memberInfoResponse = memberRepository.getMemberInfoResponseByMemberId(member.getId());
+
+        // then
+        log.info("memberInfoResponse => {}", memberInfoResponse);
+
+        assertEquals(account.getId(), memberInfoResponse.getAccountId());
+        assertEquals(member.getId(), memberInfoResponse.getMemberId());
+        assertEquals(member.getName(), memberInfoResponse.getName());
+        assertEquals(member.getEmail(), memberInfoResponse.getEmail());
+        assertEquals(member.getPhone(), memberInfoResponse.getPhone());
+        assertEquals(member.getBirthDate(), memberInfoResponse.getBirthDate());
+        assertEquals(member.getPoint(), memberInfoResponse.getPoint());
+        assertEquals(member.getGrade().getGradeId(), memberInfoResponse.getGradeId());
+        assertEquals(member.getGrade().getName(), memberInfoResponse.getGradeName());
+        assertEquals(member.getStatus().name(), memberInfoResponse.getStatus().name());
+        assertEquals(member.getRole().name(), memberInfoResponse.getRole().name());
+    }
+}

--- a/src/test/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryTest.java
@@ -24,8 +24,10 @@ import org.springframework.context.annotation.Import;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 @DataJpaTest
@@ -83,9 +85,12 @@ class MemberRepositoryTest {
                 .build());
 
         // when
-        MemberInfoResponse memberInfoResponse = memberRepository.getMemberInfoResponseByMemberId(member.getId());
+        Optional<MemberInfoResponse> optMemberInfoResponse = memberRepository.getMemberInfoResponseByMemberId(member.getId());
 
         // then
+        assertTrue(optMemberInfoResponse.isPresent());
+
+        MemberInfoResponse memberInfoResponse = optMemberInfoResponse.get();
         log.info("memberInfoResponse => {}", memberInfoResponse);
 
         assertEquals(account.getId(), memberInfoResponse.getAccountId());


### PR DESCRIPTION
## **회원 기본 정보 관련**
- [x] 회원 정보 조회
  - https://github.com/nhnacademy-be5-T3Team/bookstore-api/issues/89
  - [x] 회원 정보 조회 시 계정 아이디도 같이 불러오도록 수정
- [x] 비밀번호 변경
  - https://github.com/nhnacademy-be5-T3Team/bookstore-api/issues/139
  - [x] 현재 비밀번호가 맞는지 확인하는 과정과 변경하는 API
- [x] 회원 탈퇴
  - https://github.com/nhnacademy-be5-T3Team/bookstore-api/issues/147
  - [x] 계정 Soft Delete
  - [x] 회원 정보 Soft Delete

## **주소 관련**
- [x] 기본 주소 설정
  - https://github.com/nhnacademy-be5-T3Team/bookstore-api/issues/145
  - [x] 여러 주소 중 기본으로 사용할 주소를 표시하기 위한 필드 추가
  - [x] `MemberAddress` 엔티티에 추가된 필드 반영
  - [x] 기본 주소 설정 및 변경 API
- [x] 회원 주소 등록
  - https://github.com/nhnacademy-be5-T3Team/bookstore-api/issues/97
- [x] 회원 주소 조회
  - https://github.com/nhnacademy-be5-T3Team/bookstore-api/issues/96
- [x] 회원 주소 별칭 변경
   - https://github.com/nhnacademy-be5-T3Team/bookstore-api/issues/148
- [x] 회원 주소 삭제
  - https://github.com/nhnacademy-be5-T3Team/bookstore-api/issues/146


