### PR TITLE
Feature/member-inactive-#154 휴면 회원 처리 및 활성화 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,14 @@
 		<spring-cloud.version>2021.0.8</spring-cloud.version>
 	</properties>
 
+	<repositories>
+		<repository>
+			<id>release</id>
+			<name>edu-springboot</name>
+			<url>https://github.com/edu-springboot/edu-springboot-maven-repo/raw/master/releases</url>
+		</repository>
+	</repositories>
+
 	<dependencyManagement>
 	<dependencies>
 		<dependency>
@@ -117,6 +125,11 @@
 		<dependency>
 			<groupId>com.querydsl</groupId>
 			<artifactId>querydsl-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.nhn.dooray.messenger</groupId>
+			<artifactId>dooray-hook-sender</artifactId>
+			<version>1.2.0-RELEASE</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/t3t/bookstoreapi/BookstoreApiApplication.java
+++ b/src/main/java/com/t3t/bookstoreapi/BookstoreApiApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableDiscoveryClient
 @ConfigurationPropertiesScan
 @SpringBootApplication

--- a/src/main/java/com/t3t/bookstoreapi/certcode/controller/CertCodeController.java
+++ b/src/main/java/com/t3t/bookstoreapi/certcode/controller/CertCodeController.java
@@ -23,4 +23,20 @@ public class CertCodeController {
         certCodeService.issueMemberActivationCertCode(memberId);
         return new BaseResponse<Void>().message("인증 코드가 발급되었습니다.");
     }
+
+
+    /**
+     * 휴면 회원 활성화 인증 코드 검증
+     *
+     * @param memberId 회원 식별자
+     * @param code    인증 코드
+     * @return
+     */
+    @PostMapping(value = "/members/{memberId}/codes", params = "type=verify")
+    @ResponseStatus(HttpStatus.OK)
+    public BaseResponse<Void> verifyMemberActivationCertCode(@PathVariable("memberId") Long memberId,
+                                                             @RequestParam("value") String code) {
+        certCodeService.verifyMemberActivationCertCode(memberId, code);
+        return new BaseResponse<Void>().message("인증 코드가 확인되었습니다.");
+    }
 }

--- a/src/main/java/com/t3t/bookstoreapi/certcode/controller/CertCodeController.java
+++ b/src/main/java/com/t3t/bookstoreapi/certcode/controller/CertCodeController.java
@@ -1,0 +1,26 @@
+package com.t3t.bookstoreapi.certcode.controller;
+
+import com.t3t.bookstoreapi.certcode.service.CertCodeService;
+import com.t3t.bookstoreapi.model.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class CertCodeController {
+
+    private final CertCodeService certCodeService;
+
+    /**
+     * 휴면 회원 활성화 인증 코드 발급
+     *
+     * @author wooody35545(구건모)
+     */
+    @PostMapping(value = "/members/{memberId}/codes", params = "type=issue")
+    @ResponseStatus(HttpStatus.CREATED)
+    public BaseResponse<Void> issueMemberActivationCertCode(@PathVariable("memberId") Long memberId) {
+        certCodeService.issueMemberActivationCertCode(memberId);
+        return new BaseResponse<Void>().message("인증 코드가 발급되었습니다.");
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/certcode/entity/CertCode.java
+++ b/src/main/java/com/t3t/bookstoreapi/certcode/entity/CertCode.java
@@ -1,0 +1,22 @@
+package com.t3t.bookstoreapi.certcode.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+/**
+ * 인증 코드 엔티티
+ * Redis 에 저장되며 5 분간 유지된다.
+ *
+ * @author woody35545(구건모)
+ */
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash(value = "cert", timeToLive = 60 * 5)
+public class CertCode {
+    @Id
+    private Long memberId;
+    private String code;
+}

--- a/src/main/java/com/t3t/bookstoreapi/certcode/exception/CertCodeNotExistsException.java
+++ b/src/main/java/com/t3t/bookstoreapi/certcode/exception/CertCodeNotExistsException.java
@@ -1,0 +1,12 @@
+package com.t3t.bookstoreapi.certcode.exception;
+
+/**
+ * 인증 코드가 존재하지 않을 때 발생하는 예외
+ *
+ * @author wooody35545(구건모)
+ */
+public class CertCodeNotExistsException extends RuntimeException {
+    public CertCodeNotExistsException() {
+        super("인증 코드가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/certcode/exception/CertCodeNotMatchesException.java
+++ b/src/main/java/com/t3t/bookstoreapi/certcode/exception/CertCodeNotMatchesException.java
@@ -1,0 +1,12 @@
+package com.t3t.bookstoreapi.certcode.exception;
+
+/**
+ * 인증 코드가 일치하지 않을 때 발생하는 예외
+ *
+ * @author woody35545(구건모)
+ */
+public class CertCodeNotMatchesException extends RuntimeException {
+    public CertCodeNotMatchesException() {
+        super("인증 코드가 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/certcode/repository/CertCodeRepository.java
+++ b/src/main/java/com/t3t/bookstoreapi/certcode/repository/CertCodeRepository.java
@@ -1,0 +1,8 @@
+package com.t3t.bookstoreapi.certcode.repository;
+
+import com.t3t.bookstoreapi.certcode.entity.CertCode;
+import org.springframework.data.repository.CrudRepository;
+
+
+public interface CertCodeRepository extends CrudRepository<CertCode, Long>{
+}

--- a/src/main/java/com/t3t/bookstoreapi/certcode/service/CertCodeService.java
+++ b/src/main/java/com/t3t/bookstoreapi/certcode/service/CertCodeService.java
@@ -1,0 +1,47 @@
+package com.t3t.bookstoreapi.certcode.service;
+
+import com.nhn.dooray.client.DoorayHook;
+import com.nhn.dooray.client.DoorayHookSender;
+import com.t3t.bookstoreapi.certcode.entity.CertCode;
+import com.t3t.bookstoreapi.certcode.repository.CertCodeRepository;
+import com.t3t.bookstoreapi.member.exception.MemberNotFoundForIdException;
+import com.t3t.bookstoreapi.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CertCodeService {
+    private final MemberRepository memberRepository;
+    private final DoorayHookSender messageSender;
+    private final CertCodeRepository certCodeRepository;
+
+    /**
+     * 인증 코드 발급
+     * @param memberId 인증 코드를 발급할 회원 식별자
+     * @author wooody35545(구건모)
+     */
+    public void issueMemberActivationCertCode(long memberId) {
+
+        if (memberRepository.existsById(memberId)) {
+            throw new MemberNotFoundForIdException(memberId);
+        }
+
+        CertCode certCode = certCodeRepository.save(CertCode.builder()
+                .memberId(memberId)
+                .code(String.format("%05d", new SecureRandom().nextInt(100000)))
+                .build());
+
+        messageSender.send(DoorayHook.builder()
+                .botName("t3t-cert-bot")
+                .text(new StringBuilder().append("[t3t-bookstore]\n")
+                        .append("회원님의 휴면 계정 활성화 인증 코드는 ")
+                        .append(certCode.getCode())
+                        .append(" 입니다.").toString())
+                .build());
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/certcode/service/CertCodeService.java
+++ b/src/main/java/com/t3t/bookstoreapi/certcode/service/CertCodeService.java
@@ -3,6 +3,8 @@ package com.t3t.bookstoreapi.certcode.service;
 import com.nhn.dooray.client.DoorayHook;
 import com.nhn.dooray.client.DoorayHookSender;
 import com.t3t.bookstoreapi.certcode.entity.CertCode;
+import com.t3t.bookstoreapi.certcode.exception.CertCodeNotExistsException;
+import com.t3t.bookstoreapi.certcode.exception.CertCodeNotMatchesException;
 import com.t3t.bookstoreapi.certcode.repository.CertCodeRepository;
 import com.t3t.bookstoreapi.member.exception.MemberNotFoundForIdException;
 import com.t3t.bookstoreapi.member.repository.MemberRepository;
@@ -22,6 +24,7 @@ public class CertCodeService {
 
     /**
      * 인증 코드 발급
+     *
      * @param memberId 인증 코드를 발급할 회원 식별자
      * @author wooody35545(구건모)
      */
@@ -43,5 +46,24 @@ public class CertCodeService {
                         .append(certCode.getCode())
                         .append(" 입니다.").toString())
                 .build());
+    }
+
+    /**
+     * 인증 코드 검증
+     *
+     * @param memberId 회원 식별자
+     * @param code     인증 코드
+     * @author wooody35545(구건모)
+     */
+    public void verifyMemberActivationCertCode(long memberId, String code) {
+
+        CertCode certCode = certCodeRepository.findById(memberId)
+                .orElseThrow(CertCodeNotExistsException::new);
+
+        if (!certCode.getCode().equals(code)) {
+            throw new CertCodeNotMatchesException();
+        }
+
+        certCodeRepository.delete(certCode);
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/certcode/service/CertCodeService.java
+++ b/src/main/java/com/t3t/bookstoreapi/certcode/service/CertCodeService.java
@@ -7,6 +7,8 @@ import com.t3t.bookstoreapi.certcode.exception.CertCodeNotExistsException;
 import com.t3t.bookstoreapi.certcode.exception.CertCodeNotMatchesException;
 import com.t3t.bookstoreapi.certcode.repository.CertCodeRepository;
 import com.t3t.bookstoreapi.member.exception.MemberNotFoundForIdException;
+import com.t3t.bookstoreapi.member.model.constant.MemberStatus;
+import com.t3t.bookstoreapi.member.model.entity.Member;
 import com.t3t.bookstoreapi.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -57,12 +59,17 @@ public class CertCodeService {
      */
     public void verifyMemberActivationCertCode(long memberId, String code) {
 
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundForIdException(memberId));
+
         CertCode certCode = certCodeRepository.findById(memberId)
                 .orElseThrow(CertCodeNotExistsException::new);
 
         if (!certCode.getCode().equals(code)) {
             throw new CertCodeNotMatchesException();
         }
+
+        member.activate();
 
         certCodeRepository.delete(certCode);
     }

--- a/src/main/java/com/t3t/bookstoreapi/certcode/service/CertCodeService.java
+++ b/src/main/java/com/t3t/bookstoreapi/certcode/service/CertCodeService.java
@@ -30,7 +30,7 @@ public class CertCodeService {
      */
     public void issueMemberActivationCertCode(long memberId) {
 
-        if (memberRepository.existsById(memberId)) {
+        if (!memberRepository.existsById(memberId)) {
             throw new MemberNotFoundForIdException(memberId);
         }
 

--- a/src/main/java/com/t3t/bookstoreapi/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/t3t/bookstoreapi/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.t3t.bookstoreapi.common.exception;
 
 import com.t3t.bookstoreapi.book.exception.BookNotFoundException;
 import com.t3t.bookstoreapi.category.exception.CategoryNotFoundException;
+import com.t3t.bookstoreapi.certcode.exception.CertCodeNotExistsException;
+import com.t3t.bookstoreapi.certcode.exception.CertCodeNotMatchesException;
 import com.t3t.bookstoreapi.member.exception.*;
 import com.t3t.bookstoreapi.model.response.BaseResponse;
 import com.t3t.bookstoreapi.order.exception.DeliveryNotFoundException;
@@ -21,6 +23,28 @@ import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+
+    /**
+     * 인증 코드가 일치하지 않을 때 발생하는 예외 처리 핸들러
+     * @author woody35545(구건모)
+     */
+    @ExceptionHandler(CertCodeNotMatchesException.class)
+    public ResponseEntity<BaseResponse<Void>> handleCertCodeNotMatchesException(CertCodeNotMatchesException certCodeNotMatchesException) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new BaseResponse<Void>().message(certCodeNotMatchesException.getMessage()));
+    }
+
+    /**
+     * 인증 코드가 존재하지 않을 때 발생하는 예외 처리 핸들러
+     * @author woody35545(구건모)
+     */
+    @ExceptionHandler(CertCodeNotExistsException.class)
+    public ResponseEntity<BaseResponse<Void>> handleCertCodeNotExistsException(CertCodeNotExistsException certCodeNotExistsException) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new BaseResponse<Void>().message(certCodeNotExistsException.getMessage()));
+    }
+
     /**
      * 회원 계정의 비밀번호 검증 시, 비밀번호가 일치하지 않을 때 발생하는 예외 처리 핸들러
      *

--- a/src/main/java/com/t3t/bookstoreapi/config/MessageSenderConfig.java
+++ b/src/main/java/com/t3t/bookstoreapi/config/MessageSenderConfig.java
@@ -1,0 +1,20 @@
+package com.t3t.bookstoreapi.config;
+
+import com.nhn.dooray.client.DoorayHookSender;
+import com.t3t.bookstoreapi.property.MessageSenderProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class MessageSenderConfig {
+    /**
+     * 메시지 전송을 위한 DoorayHookSender 빈
+     *
+     * @author woody35545(구건모)
+     */
+    @Bean
+    public DoorayHookSender messageSender(RestTemplate restTemplate, MessageSenderProperties properties) {
+        return new DoorayHookSender(restTemplate, properties.getHookUrl());
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/config/RestTemplateConfig.java
+++ b/src/main/java/com/t3t/bookstoreapi/config/RestTemplateConfig.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.security.*;
 import java.security.cert.CertificateException;
 import java.time.Duration;
+
 import com.t3t.bookstoreapi.property.SecretKeyManagerProperties;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.HttpClients;
@@ -20,9 +21,20 @@ import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class RestTemplateConfig {
+    /**
+     * RestTemplate 빈
+     * @author woody35545(구건모)
+     */
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.setReadTimeout(Duration.ofSeconds(3L))
+                .setConnectTimeout(Duration.ofSeconds(3L))
+                .build();
+    }
 
     /**
      * Secret Key Manager 인증서를 사용하여 요청을 보내기 위한 RestTemplate 빈 등록
+     *
      * @author woody35545(구건모)
      */
     @Bean

--- a/src/main/java/com/t3t/bookstoreapi/member/model/entity/Member.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/model/entity/Member.java
@@ -63,7 +63,19 @@ public class Member {
     @Comment("회원 역할")
     private MemberRole role;
 
+    /**
+     * 회원 탈퇴 처리
+     * @author wooody35545(구건모)
+     */
     public void withdraw() {
         this.status = MemberStatus.WITHDRAWAL;
+    }
+
+    /**
+     * 회원 활성화
+     * @author wooody35545(구건모)
+     */
+    public void activate(){
+        this.status = MemberStatus.ACTIVE;
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryCustom.java
@@ -15,4 +15,10 @@ public interface MemberRepositoryCustom {
      * @return 조회된 회원 정보
      */
     Optional<MemberInfoResponse> getMemberInfoResponseByMemberId(long memberId);
+
+    /**
+     * 마지막 로그인 시간을 기준으로 3 개월 이상 로그인하지 않은 회원의 활성 상태를 비활성화 상태로 변경
+     * @author woody35545(구건모)
+     */
+    void updateInactiveMemberStatus();
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/repository/MemberRepositoryCustomImpl.java
@@ -2,9 +2,13 @@ package com.t3t.bookstoreapi.member.repository;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.t3t.bookstoreapi.member.model.constant.MemberStatus;
 import com.t3t.bookstoreapi.member.model.response.MemberInfoResponse;
 import lombok.RequiredArgsConstructor;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static com.t3t.bookstoreapi.member.model.entity.QAccount.account;
@@ -12,6 +16,9 @@ import static com.t3t.bookstoreapi.member.model.entity.QMember.member;
 
 @RequiredArgsConstructor
 public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     private final JPAQueryFactory queryFactory;
 
@@ -42,5 +49,21 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                         .join(account).on(member.eq(account.member))
                         .where(member.id.eq(memberId))
                         .fetchOne());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @author woody35545(구건모)
+     */
+    @Override
+    public void updateInactiveMemberStatus() {
+        queryFactory.update(member)
+                .set(member.status, MemberStatus.INACTIVE)
+                .where(member.latestLogin.isNotNull().and(
+                        member.latestLogin.before(LocalDateTime.now().minusMonths(3))))
+                .execute();
+        entityManager.flush();
+        entityManager.clear();
     }
 }

--- a/src/main/java/com/t3t/bookstoreapi/member/service/MemberSchedulerService.java
+++ b/src/main/java/com/t3t/bookstoreapi/member/service/MemberSchedulerService.java
@@ -1,0 +1,26 @@
+package com.t3t.bookstoreapi.member.service;
+
+import com.t3t.bookstoreapi.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberSchedulerService {
+    private final MemberRepository memberRepository;
+
+    /**
+     * 회원 상태를 확인하여 비활성화 상태로 변경하는 스케줄러
+     *
+     * @author woody35545(구건모)
+     */
+    @Scheduled(fixedDelay = 1000 * 60 * 60)
+    public void memberInactiveScheduler() {
+        memberRepository.updateInactiveMemberStatus();
+    }
+}

--- a/src/main/java/com/t3t/bookstoreapi/property/MessageSenderProperties.java
+++ b/src/main/java/com/t3t/bookstoreapi/property/MessageSenderProperties.java
@@ -1,0 +1,17 @@
+package com.t3t.bookstoreapi.property;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 메시지 전송을 위한 속성을 저장하는 프로퍼티 클래스
+ *
+ * @author woody35545(구건모)
+ */
+@ConfigurationProperties(prefix = "t3t.message")
+@Getter
+@Setter
+public class MessageSenderProperties {
+    private String hookUrl;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,9 @@ spring:
       matching-strategy: ant_path_matcher
 
 t3t:
+  message:
+    hookUrl: "https://hook.dooray.com/services/3204376758577275363/3740692380402107577/BVSloNkTRAqQg_rv1asoNQ"
+
   swagger:
     title: "t3t-swagger"
     description: "t3t api documentation"


### PR DESCRIPTION
- [x] 마지막 로그인 시간 기준 3개월 이상 로그인하지 않은 사용자 비활성화 처리
- [x] 인증 코드 전송을 위한 Message Sender 설정
- [x] 인증 코드 관리를 위한 Redis 엔티티
- [x] 휴면 계정 활성화 인증 코드 생성 API
- [x] 휴면 계정 활성화 인증 코드 검증 API
